### PR TITLE
improve solution #284 of fixing BCE loss w/o mixup

### DIFF
--- a/mindcv/data/mixup.py
+++ b/mindcv/data/mixup.py
@@ -1,17 +1,3 @@
-# Copyright 2021 Huawei Technologies Co., Ltd
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ============================================================================
 """ Mixup and Cutmix
 
 Papers:
@@ -39,16 +25,12 @@ def one_hot(x, num_classes, on_value=1.0, off_value=0.0):
     return x
 
 
-def mixup_target(target, num_classes, lam=1.0, smoothing=0.0, is_onehot_label=False):
+def mixup_target(target, num_classes, lam=1.0, smoothing=0.0):
     """mixup_target"""
-    if not is_onehot_label:
-        off_value = smoothing / num_classes
-        on_value = 1.0 - smoothing + off_value
-        y1 = one_hot(target, num_classes, on_value=on_value, off_value=off_value)
-        y2 = one_hot(np.flip(target, axis=0), num_classes, on_value=on_value, off_value=off_value)
-    else:
-        y1 = target
-        y2 = np.flip(target)
+    off_value = smoothing / num_classes
+    on_value = 1.0 - smoothing + off_value
+    y1 = one_hot(target, num_classes, on_value=on_value, off_value=off_value)
+    y2 = one_hot(np.flip(target, axis=0), num_classes, on_value=on_value, off_value=off_value)
     return y1 * lam + y2 * (1.0 - lam)
 
 
@@ -124,7 +106,6 @@ class Mixup:
         correct_lam (bool): apply lambda correction when cutmix bbox clipped by image borders
         label_smoothing (float): apply label smoothing to the mixed target tensor
         num_classes (int): number of classes for target
-        is_onehot_label (bool): indicate wheter the input label is onehot format.
     """
 
     def __init__(
@@ -138,7 +119,6 @@ class Mixup:
         correct_lam=True,
         label_smoothing=0.1,
         num_classes=1000,
-        is_onehot_label=False,
     ):
         self.mixup_alpha = mixup_alpha
         self.cutmix_alpha = cutmix_alpha
@@ -154,7 +134,6 @@ class Mixup:
         self.mode = mode
         self.correct_lam = correct_lam  # correct lambda based on clipped area for cutmix
         self.mixup_enabled = True  # set false to disable mixing (intended tp be set by train loop)
-        self.is_onehot_label = is_onehot_label
 
     def _params_per_elem(self, batch_size):
         """_params_per_elem"""
@@ -267,5 +246,5 @@ class Mixup:
             lam = self._mix_pair(x)
         else:
             lam = self._mix_batch(x)
-        target = mixup_target(target, self.num_classes, lam, self.label_smoothing, is_onehot_label=self.is_onehot_label)
+        target = mixup_target(target, self.num_classes, lam, self.label_smoothing)
         return x.astype(np.float32), target.astype(np.float32)

--- a/train.py
+++ b/train.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 import mindspore as ms
-import mindspore.dataset.transforms as transforms
 from mindspore import FixedLossScaleManager, Model, Tensor, nn
 from mindspore.communication import get_group_size, get_rank, init
 
@@ -85,8 +84,6 @@ def train(args):
         re_max_attempts=args.re_max_attempts,
     )
 
-    target_transform = transforms.OneHot(num_classes) if args.loss == "BCE" else None
-
     # load dataset
     loader_train = create_loader(
         dataset=dataset_train,
@@ -98,7 +95,6 @@ def train(args):
         cutmix_prob=args.cutmix_prob,
         num_classes=num_classes,
         transform=transform_list,
-        target_transform=target_transform,
         num_parallel_workers=args.num_parallel_workers,
     )
 
@@ -129,7 +125,6 @@ def train(args):
             drop_remainder=False,
             is_training=False,
             transform=transform_list_eval,
-            target_transform=target_transform,
             num_parallel_workers=args.num_parallel_workers,
         )
         # validation dataset count


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

Improve solution #284 of fixing BCE loss w/o mixup.
If we disable mixup or cutmix, then the label is not onehotted. However, `F.binary_cross_entropy_with_logits` only support onehot label which causes problem. The PR above is trying to resolve the bug by add onehot label transform when creating data loader. That's inconsistent when we use CE loss, and coupling loss and data transform together is confusing. The essence of the above problem is that the loss function does not support non-onehot mode, and this PR solves it.

## Test Plan

already in ut

## Related Issues and PRs

#284 
