### PR TITLE
[feat] add default download root instead of using current working dir

### DIFF
--- a/mindcv/data/dataset_download.py
+++ b/mindcv/data/dataset_download.py
@@ -3,14 +3,20 @@ Dataset download
 """
 
 import os
+from typing import Optional
 
-from mindcv.utils.download import DownLoad
+from mindcv.utils.download import DownLoad, get_default_download_root
 
 __all__ = [
+    "get_dataset_download_root",
     "MnistDownload",
     "Cifar10Download",
     "Cifar100Download",
 ]
+
+
+def get_dataset_download_root():
+    return os.path.join(get_default_download_root(), "datasets")
 
 
 class MnistDownload(DownLoad):
@@ -29,8 +35,10 @@ class MnistDownload(DownLoad):
         ("t10k-labels-idx1-ubyte.gz", "ec29112dd5afa0611ce80d1b7f02629c"),
     ]
 
-    def __init__(self, root: str):
+    def __init__(self, root: Optional[str] = None):
         super().__init__()
+        if root is None:
+            root = os.path.join(get_dataset_download_root(), "mnist")
         self.root = root
         self.path = root
 
@@ -77,8 +85,10 @@ class Cifar10Download(DownLoad):
         "batches.meta.txt",
     ]
 
-    def __init__(self, root: str):
+    def __init__(self, root: Optional[str] = None):
         super().__init__()
+        if root is None:
+            root = os.path.join(get_dataset_download_root(), "cifar10")
         self.root = root
         self.path = os.path.join(self.root, self.base_dir)
 
@@ -118,8 +128,10 @@ class Cifar100Download(DownLoad):
         "coarse_label_names.txt",
     ]
 
-    def __init__(self, root: str):
+    def __init__(self, root: Optional[str] = None):
         super().__init__()
+        if root is None:
+            root = os.path.join(get_dataset_download_root(), "cifar100")
         self.root = root
         self.path = os.path.join(self.root, self.base_dir)
 

--- a/mindcv/data/dataset_factory.py
+++ b/mindcv/data/dataset_factory.py
@@ -8,7 +8,7 @@ from typing import Optional
 import mindspore.dataset as ds
 from mindspore.dataset import Cifar10Dataset, Cifar100Dataset, DistributedSampler, ImageFolderDataset, MnistDataset
 
-from .dataset_download import Cifar10Download, Cifar100Download, MnistDownload
+from .dataset_download import Cifar10Download, Cifar100Download, MnistDownload, get_dataset_download_root
 from .distributed_sampler import RepeatAugSampler
 
 __all__ = [
@@ -24,10 +24,10 @@ _MINDSPORE_BASIC_DATASET = dict(
 
 def create_dataset(
     name: str = "",
-    root: str = "./",
+    root: Optional[str] = None,
     split: str = "train",
     shuffle: bool = True,
-    num_samples: Optional[bool] = None,
+    num_samples: Optional[int] = None,
     num_shards: Optional[int] = None,
     shard_id: Optional[int] = None,
     num_parallel_workers: Optional[int] = None,
@@ -39,7 +39,7 @@ def create_dataset(
 
     Args:
         name: dataset name like MNIST, CIFAR10, ImageNeT, ''. '' means a customized dataset. Default: ''.
-        root: dataset root dir. Default: './'.
+        root: dataset root dir. Default: None.
         split: data split: '' or split name string (train/val/test), if it is '', no split is used.
             Otherwise, it is a subfolder of root dir, e.g., train, val, test. Default: 'train'.
         shuffle: whether to shuffle the dataset. Default: True.
@@ -79,10 +79,12 @@ def create_dataset(
     Returns:
         Dataset object
     """
+    name = name.lower()
+    if root is None:
+        root = os.path.join(get_dataset_download_root(), name)
 
     assert (num_samples is None) or (num_aug_repeats == 0), "num_samples and num_aug_repeats can NOT be set together."
 
-    name = name.lower()
     # subset sampling
     if num_samples is not None and num_samples > 0:
         # TODO: rewrite ordered distributed sampler (subset sampling in distributed mode is not tested)

--- a/mindcv/models/utils.py
+++ b/mindcv/models/utils.py
@@ -9,7 +9,11 @@ from typing import List, Optional
 
 from mindspore import load_checkpoint, load_param_into_net
 
-from mindcv.utils.download import DownLoad
+from mindcv.utils.download import DownLoad, get_default_download_root
+
+
+def get_checkpoint_download_root():
+    return os.path.join(get_default_download_root(), "models")
 
 
 class ConfigDict(dict):
@@ -20,17 +24,18 @@ class ConfigDict(dict):
     __delattr__ = dict.__delitem__
 
 
-def load_pretrained(model, default_cfg, path="./", num_classes=1000, in_channels=3, filter_fn=None):
+def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_fn=None):
     """load pretrained model depending on cfgs of model"""
     if "url" not in default_cfg or not default_cfg["url"]:
         logging.warning("Pretrained model URL is invalid")
         return
 
     # download files
-    os.makedirs(path, exist_ok=True)
-    DownLoad().download_url(default_cfg["url"], path=path)
+    download_path = get_checkpoint_download_root()
+    os.makedirs(download_path, exist_ok=True)
+    DownLoad().download_url(default_cfg["url"], path=download_path)
 
-    param_dict = load_checkpoint(os.path.join(path, os.path.basename(default_cfg["url"])))
+    param_dict = load_checkpoint(os.path.join(download_path, os.path.basename(default_cfg["url"])))
 
     if in_channels == 1:
         conv1_name = default_cfg["first_conv"]


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

Set the default download root path as `~/.mindspore`(hereinafter referred to as `${DOWNLOAD_ROOT}`) instead of using the current working directory.
For different types of files, we place them in:
- Checkpoints of pretrained model: `${DOWNLOAD_ROOT}/models`
- Small datasets like mnist cifair10: `${DOWNLOAD_ROOT}/datasets`

We can change the default download path with function `set_default_download_root`, or explicitly pass in the download path when calling function `download_and_extract_archive` or `download_url`.

## Test Plan

Already in tests.

## Related Issues and PRs

None
