### PR TITLE
[feat] add trainer factory

### DIFF
--- a/config.py
+++ b/config.py
@@ -224,11 +224,14 @@ def create_parser():
                        help='Amp level - Auto Mixed Precision level for saving memory and acceleration. '
                             'Choice: O0 - all FP32, O1 - only cast ops in white-list to FP16, '
                             'O2 - cast all ops except for blacklist to FP16, '
-                            'O3 - cast all ops to FP16 (default="O0")')
+                            'O3 - cast all ops to FP16. (default="O0").')
+    group.add_argument('--loss_scale_type', type=str, default='fixed',
+                       choices=['fixed', 'dynamic', 'auto'],
+                       help='The type of loss scale (default="fixed")')
     group.add_argument('--loss_scale', type=float, default=1.0,
                        help='Loss scale (default=1.0)')
-    group.add_argument('--dynamic_loss_scale', type=str2bool, nargs='?', const=True, default=False,
-                       help='Whether to use dynamic loss scale (default=False)')
+    group.add_argument('--drop_overflow_update', type=bool, default=False,
+                       help='Whether to execute optimizer if there is an overflow (default=False)')
 
     # modelarts
     group = parser.add_argument_group('modelarts')

--- a/mindcv/engine/__init__.py
+++ b/mindcv/engine/__init__.py
@@ -1,6 +1,10 @@
 """Engine Tools"""
-
+from . import callbacks, train_step, trainer_factory
 from .callbacks import *
 from .train_step import *
+from .trainer_factory import *
 
 __all__ = []
+__all__.extend(callbacks.__all__)
+__all__.extend(train_step.__all__)
+__all__.extend(trainer_factory.__all__)

--- a/mindcv/engine/callbacks.py
+++ b/mindcv/engine/callbacks.py
@@ -13,6 +13,11 @@ from mindspore.train.callback import Callback
 
 from mindcv.utils import AllReduceSum, CheckpointManager
 
+__all__ = [
+    "StateMonitor",
+    "ValCallback",
+]
+
 
 class StateMonitor(Callback):
     """

--- a/mindcv/engine/train_step.py
+++ b/mindcv/engine/train_step.py
@@ -6,6 +6,10 @@ from mindspore.ops import composite as C
 from mindspore.ops import functional as F
 from mindspore.ops import operations as P
 
+__all__ = [
+    "TrainStep",
+]
+
 _ema_op = C.MultitypeFuncGraph("grad_ema_op")
 _grad_scale = C.MultitypeFuncGraph("grad_scale")
 reciprocal = P.Reciprocal()

--- a/mindcv/engine/trainer_factory.py
+++ b/mindcv/engine/trainer_factory.py
@@ -1,0 +1,134 @@
+import logging
+from typing import Union
+
+import mindspore as ms
+from mindspore import nn
+from mindspore.train import DynamicLossScaleManager, FixedLossScaleManager, Model
+
+from .train_step import TrainStep
+
+__all__ = [
+    "get_metrics",
+    "create_trainer",
+]
+
+_logger = logging.getLogger(__name__)
+
+
+def get_metrics(num_classes):
+    if num_classes >= 5:
+        metrics = {
+            "Top_1_Accuracy": nn.Top1CategoricalAccuracy(),
+            "Top_5_Accuracy": nn.Top5CategoricalAccuracy(),
+        }
+    else:
+        metrics = {
+            "Top_1_Accuracy": nn.Top1CategoricalAccuracy(),
+        }
+    return metrics
+
+
+def _require_customized_train_step(ema: bool = False, clip_grad: bool = False):
+    if ema:
+        return True
+    if clip_grad:
+        return True
+    return False
+
+
+def create_trainer(
+    network: nn.Cell,
+    loss: nn.Cell,
+    optimizer: nn.Cell,
+    metrics: Union[dict, set],
+    amp_level: str,
+    loss_scale_type: str,
+    loss_scale: float = 1.0,
+    drop_overflow_update: bool = False,
+    ema: bool = False,
+    ema_decay: float = 0.9999,
+    clip_grad: bool = False,
+    clip_value: float = 15.0,
+):
+    """Create Trainer.
+
+    Args:
+        network: The backbone network to train, evaluate or predict.
+        loss: The function of calculating loss.
+        optimizer: The optimizer for training.
+        metrics: The metrics for model evaluation.
+        amp_level: The level of auto mixing precision training.
+        loss_scale_type: The type of loss scale.
+        loss_scale: The value of loss scale.
+        drop_overflow_update: Whether to execute optimizer if there is an overflow.
+        ema: Whether to use exponential moving average of model weights.
+        ema_decay: Decay factor for model weights moving average.
+        clip_grad: whether to gradient clip.
+        clip_value: The value at which to clip gradients.
+
+    Returns:
+        mindspore.Model
+
+    """
+    if loss_scale < 1.0:
+        raise ValueError("Loss scale cannot be less than 1.0!")
+
+    if drop_overflow_update is False and loss_scale_type.lower() == "dynamic":
+        raise ValueError("DynamicLossScale ALWAYS drop overflow!")
+
+    if not _require_customized_train_step(ema, clip_grad):
+        mindspore_kwargs = dict(
+            network=network,
+            loss_fn=loss,
+            optimizer=optimizer,
+            metrics=metrics,
+            amp_level=amp_level,
+        )
+        if loss_scale_type.lower() == "fixed":
+            mindspore_kwargs["loss_scale_manager"] = FixedLossScaleManager(
+                loss_scale=loss_scale, drop_overflow_update=drop_overflow_update
+            )
+        elif loss_scale_type.lower() == "dynamic":
+            mindspore_kwargs["loss_scale_manager"] = DynamicLossScaleManager(
+                init_loss_scale=loss_scale, scale_factor=2, scale_window=2000
+            )
+        elif loss_scale_type.lower() == "auto":
+            # We don't explicitly construct LossScaleManager
+            _logger.warning(
+                "You are using AUTO loss scale, which means the LossScaleManager isn't explicitly pass in "
+                "when creating a mindspore.Model instance. "
+                "NOTE: mindspore.Model may use LossScaleManager silently. See mindspore.train.amp for details."
+            )
+        else:
+            raise ValueError(f"Loss scale type only support ['fixed', 'dynamic', 'auto'], but got{loss_scale_type}.")
+        model = Model(**mindspore_kwargs)
+    else:  # require customized train step
+        net_with_loss = nn.WithLossCell(network, loss)
+        ms.amp.auto_mixed_precision(net_with_loss, amp_level=amp_level)
+        train_step_kwargs = dict(
+            network=net_with_loss,
+            optimizer=optimizer,
+            ema=ema,
+            ema_decay=ema_decay,
+            clip_grad=clip_grad,
+            clip_value=clip_value,
+        )
+        if loss_scale_type.lower() == "fixed":
+            # todo: drop_overflow_update. If drop_overflow_update is False, scale_sense should be a number
+            #  instead of cell, and TrainStep should be TrainOneStepCell. If drop_overflow_update is True,
+            #  scale_sense should be FixedLossScaleUpdateCell, and TrainStep should be TrainOneStepWithLossScaleCell.
+            train_step_kwargs["scale_sense"] = nn.FixedLossScaleUpdateCell(loss_scale_value=loss_scale)
+        elif loss_scale_type.lower() == "dynamic":
+            train_step_kwargs["scale_sense"] = nn.DynamicLossScaleUpdateCell(
+                loss_scale_value=loss_scale, scale_factor=2, scale_window=2000
+            )
+        else:
+            raise ValueError(f"Loss scale type only support ['fixed', 'dynamic'], but got{loss_scale_type}.")
+        # todo: remove this check when TrainStep support dynamic loss scale and dropping overflow
+        if drop_overflow_update or loss_scale_type.lower() != "fixed":
+            raise ValueError("TrainStep only support fixed loss scale without dropping overflow!")
+        train_step_cell = TrainStep(**train_step_kwargs)
+        eval_network = nn.WithEvalCell(network, loss, amp_level in ["O2", "O3", "auto"])
+        model = Model(train_step_cell, eval_network=eval_network, metrics=metrics, eval_indexes=[0, 1, 2])
+        # todo: do we need to set model._loss_scale_manager
+    return model


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

We abstracted the fragment of the training script about creating a `mindspore.Model` (actually a Trainer) into the function `create_trainer`, a factory method of creating trainers. We believe this abstraction facilitates code readability.

When creating the trainer we need to pass in common components such as networks, optimizer, loss functions etc. as input parameters. Meanwhile, we also need to pass in additional parameters to support Auto Mixed Precision(AMP). Next, we elaborate on the creator's design and principles regarding AMP in details.

1. The level of amp:
   We follow the definition from [MindSpore](https://www.mindspore.cn/docs/zh-CN/master/api_python/amp/mindspore.amp.auto_mixed_precision.html)
   We may subsequently consider **customized** black and white lists

2. The type of loss scale:
   - fixed(w/ or w/o drop_overflow_update)
   - dynamic
   - auto

   For `fixed` or `dynamic`, we will explicitly construct the `LossScaleManager` and pass in `mindspore.Model`. For `auto`, we will not actively construct the `LossScaleManager`, but `mindspore.Model` may use the `LossScaleManager` silently, see [mindspore.train.amp](https://gitee.com/mindspore/mindspore/blob/master/mindspore/python/mindspore/train/amp.py) for details.

3. The value of loss scale
   We will raise an error if the value of loss scale is less than 1. We no longer make a special case for `loss_scale=1`, although for a while we did. You can now set the type of loss scale to `auto` to achieve the same effect.

We have also considered support for customized `TrainStep`. The current customized `TrainStep` supports EMA and gradient clipping. Note: the current customized `TrainStep` can only be used with fixed loss scale without dropping overflow!

## Test Plan

st is already in `tests/tasks/test_train_val_imagenet_subset.py`. Do we need an additional unit test?

## Related Issues and PRs

Nope
