### PR TITLE
Fix the typo of model name in nasnet_a_4x1056_ascend.yaml

### DIFF
--- a/configs/nasnet/nasnet_a_4x1056_ascend.yaml
+++ b/configs/nasnet/nasnet_a_4x1056_ascend.yaml
@@ -21,7 +21,7 @@ interpolation: 'bilinear'
 crop_pct: 0.875
 
 # model
-model: 'nasnet'
+model: 'nasnet_a_4x1056'
 num_classes: 1000
 pretrained: False
 ckpt_path: ''


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

The typo of model name in nasnet_a_4x1056_ascend.yaml is fixed.

## Test Plan

Please refer to the validation part in 'configs/nasnet/README.md' for testing.

## Related Issues and PRs

Related issue: https://github.com/mindspore-lab/mindcv/issues/438
Related PR: https://github.com/mindspore-lab/mindcv/pull/509
