### PR TITLE
[hotfix] disable parameter_broadcast when invoking set_auto_parallel_context

### DIFF
--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ def train(args):
             device_num=device_num,
             parallel_mode="data_parallel",
             gradients_mean=True,
-            parameter_broadcast=True,
+            # we should but cannot set parameter_broadcast=True, which will cause error on gpu.
         )
     else:
         device_num = None


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

We should but cannot set parameter_broadcast=True when invoking `set_auto_parallel_context`, which will cause error on gpu. It's seems to be a weird bug of MindSpore and the reason is still unknown.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

inroduced by #487 
fixes #528 
