### PR TITLE
Support feature pyramid extraction

### DIFF
--- a/mindcv/models/_feature.py
+++ b/mindcv/models/_feature.py
@@ -1,0 +1,118 @@
+from collections import OrderedDict
+from typing import Any, Dict, Iterable, List, Tuple
+
+import mindspore.nn as nn
+from mindspore import Tensor
+
+
+def _cell_list(net: nn.Cell, flatten_sequential: bool = False) -> Iterable[Tuple[str, str, nn.Cell]]:
+    """Yield the partially flattened cell list from the model, together with its new name and old name
+
+    Args:
+        net (nn.Cell): Network need to be partially flattened
+        flatten_sequential (bool): Flatten the inner-layer of the sequential cell. Default: False.
+
+    Returns:
+        iterator[tuple[str, str, nn.Cell]]: The new name, the old name and corresponding cell
+    """
+    for name, cell in net.name_cells().items():
+        if flatten_sequential and isinstance(cell, nn.SequentialCell):
+            for child_name, child_cell in cell.name_cells().items():
+                combined = [name, child_name]
+                yield "_".join(combined), ".".join(combined), child_cell
+        else:
+            yield name, name, cell
+
+
+def _get_return_layers(feature_info: Dict[str, Any], out_indices: List[int]) -> Dict[str, int]:
+    """Create a dict storing the "layer_name - layer_id" pair that need to be extracted"""
+    return_layers = dict()
+    for i, x in enumerate(feature_info):
+        if i in out_indices:
+            return_layers[x["name"]] = i
+    return return_layers
+
+
+class FeatureExtractWrapper(nn.Cell):
+    """A wrapper of the original model, aims to perform the feature extraction at each stride.
+    Basically, it performs 3 steps: 1. extract the return node name from the network's property
+    `feature_info`; 2. partially flatten the network architecture if network's attribute `flatten_sequential`
+    is True; 3. rebuild the forward steps and output the features based on the return node name.
+
+    It also provide a property `out_channels` in the wrapped model, return the number of features at each output
+    layer. This propery is usually used for the downstream tasks, which requires feature infomation at network
+    build stage.
+
+    It should be note that to apply this wrapper, there is a strong assumption that each of the outmost cell
+    are registered in the same order as they are used. And there should be no reuse of each cell, even for the `ReLU`
+    cell. Otherwise, the returned result may not be correct.
+
+    And it should be also note that it basically rebuild the model. So the default checkpoint parameter cannot be loaded
+    correctly once that model is wrapped. To use the pretrained weight, please load the weight first and then use this
+    wrapper to rebuild the model.
+
+    Args:
+        net (nn.Cell): The model need to be wrapped.
+        out_indices (list[int]): The indicies of the output features. Default: [0, 1, 2, 3, 4]
+    """
+
+    def __init__(self, net: nn.Cell, out_indices: List[int] = [0, 1, 2, 3, 4]) -> None:
+        super().__init__(auto_prefix=False)
+
+        feature_info = self._get_feature_info(net)
+        flatten_sequetial = getattr(net, "flatten_sequential", False)
+        cells = _cell_list(net, flatten_sequential=flatten_sequetial)
+        return_layers = _get_return_layers(feature_info, out_indices)
+        self.net, updated_return_layers = self._create_net(cells, return_layers)
+
+        # calculate the return index
+        self.return_index = list()
+        for i, name in enumerate(self.net.name_cells().keys()):
+            if name in updated_return_layers:
+                self.return_index.append(i)
+
+        # calculate the out_channels
+        self._out_channels = list()
+        for i in return_layers.values():
+            self._out_channels.append(feature_info[i]["chs"])
+
+    @property
+    def out_channels(self):
+        """The output channels of the model, filtered by the out_indices.
+        """
+        return self._out_channels
+
+    def construct(self, x: Tensor) -> List[Tensor]:
+        return self._collect(x)
+
+    def _get_feature_info(self, net: nn.Cell) -> Dict[str, Any]:
+        try:
+            feature_info = getattr(net, "feature_info")
+        except AttributeError:
+            raise
+        return feature_info
+
+    def _create_net(
+        self, cells: Iterable[Tuple[str, str, nn.Cell]], return_layers: Dict[str, int]
+    ) -> Tuple[nn.SequentialCell, Dict[str, int]]:
+        layers = OrderedDict()
+        updated_return_layers = dict()
+        remaining = set(return_layers.keys())
+        for new_name, old_name, module in cells:
+            layers[new_name] = module
+            if old_name in remaining:
+                updated_return_layers[new_name] = return_layers[old_name]
+                remaining.remove(old_name)
+            if not remaining:
+                break
+
+        net = nn.SequentialCell(layers)
+        return net, updated_return_layers
+
+    def _collect(self, x: Tensor) -> List[Tensor]:
+        out = list()
+        for i, cell in enumerate(self.net.cell_list):
+            x = cell(x)
+            if i in self.return_index:
+                out.append(x)
+        return out

--- a/mindcv/models/model_template.md
+++ b/mindcv/models/model_template.md
@@ -122,6 +122,8 @@ The main model is the network model definition proposed in the paper, which is c
 - `forward_head` function. The operation of the classifier of the model is defined in the function.
 - `construct` function. In function call feature network and classifier operation.
 - `_initialize_weights` function. We agree that the random initialization of model parameters is completed by this member function. See code below.
+- `feature_info` property. This property provides the detail information of the features of the network, and it is usually necessary for the feature pyramid extraction in the downstream tasks. This property maintains a list of dictionary. And each dictionary contains {"chs", "reduction", "name"} three keys, which corredsponds to the number of channels, the scale of downsampling and the node name in the network. For example, {"chs": 64, "reduction": 4, "name": "layer1"} means that the feature has 64 feature channels, it has a 4 scale reduction for downsampling, and the corredsponding node name is ".layer1". If the master model does not have feature_info property, it means that the model does not support feature pyramid extraction at this stage. You can refer to "resnet" for the detail implementation.
+- `flatten_sequential` property. This propety is a boolean value, which means that if the model needs to do a flatten operation at the feature pyramid extraction stage, by default it is False. When the feature outputs are the outmost layers of the network (e.g., our `resnet` implementation), flatten_sequential is False. However, when the feature outputs are the second inner layers of the network (e.g., our `vgg` implementation), this propery must set to be True.
 
 Examples are as follows:
 

--- a/mindcv/models/model_template_CN.md
+++ b/mindcv/models/model_template_CN.md
@@ -121,7 +121,7 @@ class MixerBlock(nn.Cell):
 - `construct`函数。在函数调用特征网络和分类器的运算。
 - `_initialize_weights`函数。我们约定模型参数的随机初始化由该成员函数完成。详见下方代码。
 - `feature_info`属性。此属性提供了网络特征的具体信息，通常用来做下游任务中的多特征提取。此属性为一个字典列表，每一个字典包含["chs", "reduction", “name”]三個Key, 分别代表该特征的channel大小，向下采样倍率和对应的网络节点名字。例如，{"chs": 64, "reduction": 4, "name": "layer1"}代表该特征有64个channel，为输入图片的4倍下采样，并且代表的网络节点为“.layer1”。如果主模型没有feature_info属性，代表该网络尚未支持多特征提取。已支持模型可参考resnet。
-- `flatten_sequential`属性。此属性为一个bool常量，代表该模型在做多特征提取时是否需要做结构平坦化，缺省值为False。当特征提取节点为网络的最外层时（如resnet的实现），该属性可以为False；当特征提取为网络结构的内二层时（如vgg的实现），该属性必须为True。
+- `flatten_sequential`属性。此属性为一个bool常量，代表该模型在做多特征提取时是否需要做结构平坦化，缺省值为False。当特征提取节点为网络的最外层时（如resnet的实现），该属性为False；当特征提取为网络结构的内二层时（如vgg的实现），该属性必须为True。
 
 示例如下：
 

--- a/mindcv/models/model_template_CN.md
+++ b/mindcv/models/model_template_CN.md
@@ -120,6 +120,8 @@ class MixerBlock(nn.Cell):
 - `forward_head`函数。在函数内对模型的分类器的运算进行定义。
 - `construct`函数。在函数调用特征网络和分类器的运算。
 - `_initialize_weights`函数。我们约定模型参数的随机初始化由该成员函数完成。详见下方代码。
+- `feature_info`属性。此属性提供了网络特征的具体信息，通常用来做下游任务中的多特征提取。此属性为一个字典列表，每一个字典包含["chs", "reduction", “name”]三個Key, 分别代表该特征的channel大小，向下采样倍率和对应的网络节点名字。例如，{"chs": 64, "reduction": 4, "name": "layer1"}代表该特征有64个channel，为输入图片的4倍下采样，并且代表的网络节点为“.layer1”。如果主模型没有feature_info属性，代表该网络尚未支持多特征提取。已支持模型可参考resnet。
+- `flatten_sequential`属性。此属性为一个bool常量，代表该模型在做多特征提取时是否需要做结构平坦化，缺省值为False。当特征提取节点为网络的最外层时（如resnet的实现），该属性可以为False；当特征提取为网络结构的内二层时（如vgg的实现），该属性必须为True。
 
 示例如下：
 

--- a/mindcv/models/resnet.py
+++ b/mindcv/models/resnet.py
@@ -197,11 +197,12 @@ class ResNet(nn.Cell):
                                stride=2, pad_mode="pad", padding=3)
         self.bn1 = norm(self.input_channels)
         self.relu = nn.ReLU()
+        self.feature_info = [dict(chs=self.input_channels, reduction=2, name="relu")]
         self.max_pool = nn.MaxPool2d(kernel_size=3, stride=2, pad_mode="same")
-        self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        self.layer1 = self._make_layer(block, 64, layers[0], name="layer1", reduction=4)
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2, name="layer2", reduction=8)
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2, name="layer3", reduction=16)
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2, name="layer4", reduction=32)
 
         self.pool = GlobalAvgPooling()
         self.num_features = 512 * block.expansion
@@ -235,6 +236,8 @@ class ResNet(nn.Cell):
         channels: int,
         block_nums: int,
         stride: int = 1,
+        name: str = "",
+        reduction: int = 1,
     ) -> nn.SequentialCell:
         """build model depending on cfgs"""
         down_sample = None
@@ -269,6 +272,8 @@ class ResNet(nn.Cell):
                     norm=self.norm
                 )
             )
+
+        self.feature_info.append(dict(chs=self.input_channels, reduction=reduction, name=name))
 
         return nn.SequentialCell(layers)
 

--- a/mindcv/models/sknet.py
+++ b/mindcv/models/sknet.py
@@ -176,6 +176,8 @@ class SKNet(ResNet):
         channels: int,
         block_nums: int,
         stride: int = 1,
+        name: str = "",
+        reduction: int = 1,
     ) -> nn.SequentialCell:
         down_sample = None
 

--- a/quick_start.md
+++ b/quick_start.md
@@ -182,6 +182,10 @@ network = create_model(model_name='densenet121', num_classes=num_classes, pretra
 
 - checkpoint_path: The path of checkpoint files. Default: “”.
 
+- features_only: Perform the feature extraction. Default: False
+
+- out_indices: The indicies of the output features when `features_only` is True. Default: [0, 1, 2, 3, 4]
+
 - use_ema: Whether use ema method. Default: False.
 
 Use the [mindcv.loss.create_loss](https://mindcv.readthedocs.io/en/latest/api/mindcv.loss.html#mindcv.loss.create_loss) interface to create a loss function (cross_entropy loss).

--- a/quick_start_CN.md
+++ b/quick_start_CN.md
@@ -181,6 +181,10 @@ network = create_model(model_name='densenet121', num_classes=num_classes, pretra
 
 - checkpoint_path：checkpoint的路径。默认值：“ ”。
 
+- features_only：进行多尺度的特征提取。默认值：False。
+
+- out_indices：当features_only为True时，多尺度特征提取的对应索引值。默认值：[0, 1, 2, 3, 4]
+
 - ema：是否使用ema方法 默认值: False。
 
 使用[mindcv.loss.create_loss](https://mindcv.readthedocs.io/en/latest/api/mindcv.loss.html#mindcv.loss.create_loss)接口创建损失函数（cross_entropy loss）。

--- a/tests/modules/test_feature_extraction.py
+++ b/tests/modules/test_feature_extraction.py
@@ -83,7 +83,8 @@ class SimpleCNNWithInnerSequential(nn.Cell):
 
 
 @pytest.mark.parametrize("mode", [0, 1])
-def test_feature_extraction_result_using_feature_wrapper():
+def test_feature_extraction_result_using_feature_wrapper(mode):
+    ms.set_context(mode=mode)
     np.random.seed(0)
 
     net = SimpleCNN()
@@ -100,7 +101,8 @@ def test_feature_extraction_result_using_feature_wrapper():
 
 
 @pytest.mark.parametrize("mode", [0, 1])
-def test_feature_extraction_result_using_feature_wrapper_with_flatten_sequential():
+def test_feature_extraction_result_using_feature_wrapper_with_flatten_sequential(mode):
+    ms.set_context(mode=mode)
     np.random.seed(0)
 
     net = SimpleCNNWithInnerSequential()
@@ -117,7 +119,8 @@ def test_feature_extraction_result_using_feature_wrapper_with_flatten_sequential
 
 
 @pytest.mark.parametrize("mode", [0, 1])
-def test_feature_extraction_indices_using_feature_wrapper():
+def test_feature_extraction_indices_using_feature_wrapper(mode):
+    ms.set_context(mode=mode)
     np.random.seed(0)
 
     net = SimpleCNN()

--- a/tests/modules/test_feature_extraction.py
+++ b/tests/modules/test_feature_extraction.py
@@ -1,0 +1,133 @@
+import numpy as np
+import pytest
+
+import mindspore as ms
+import mindspore.nn as nn
+
+from mindcv.models._feature import FeatureExtractWrapper
+
+
+class Conv2dReLU(nn.Cell):
+    def __init__(self, in_channels, out_channels, kernel_size, downsample=False):
+        super().__init__()
+        self.downsample = downsample
+        if self.downsample:
+            self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, pad_mode="valid")
+        self.relu = nn.ReLU()
+
+    def construct(self, x):
+        if self.downsample:
+            x = self.pool(x)
+        x = self.conv(x)
+        x = self.relu(x)
+        return x
+
+
+class SimpleCNN(nn.Cell):
+    def __init__(self, in_channels=1):
+        super(SimpleCNN, self).__init__()
+        self.block1 = Conv2dReLU(in_channels, 6, 5, False)
+        self.block2 = Conv2dReLU(6, 8, 5, True)
+        self.block3 = Conv2dReLU(8, 8, 5, True)
+
+        self.feature_info = [
+            {"chs": 6, "reduction": 1, "name": "block1"},
+            {"chs": 8, "reduction": 2, "name": "block2"},
+            {"chs": 8, "reduction": 4, "name": "block3"},
+        ]
+
+    def forward_features(self, x):
+        x = self.block1(x)
+        x = self.block2(x)
+        x = self.block3(x)
+        return x
+
+    def forward_multi_features(self, x):
+        x1 = self.block1(x)
+        x2 = self.block2(x1)
+        x3 = self.block3(x2)
+        return [x1, x2, x3]
+
+    def construct(self, x):
+        return self.forward_features(x)
+
+
+class SimpleCNNWithInnerSequential(nn.Cell):
+    def __init__(self, in_channels=1):
+        super(SimpleCNNWithInnerSequential, self).__init__()
+        block1 = Conv2dReLU(in_channels, 6, 5, False)
+        block2 = Conv2dReLU(6, 8, 5, True)
+        block3 = Conv2dReLU(8, 8, 5, True)
+        self.feature = nn.SequentialCell([block1, block2, block3])
+
+        self.feature_info = [
+            {"chs": 6, "reduction": 1, "name": "feature.0"},
+            {"chs": 8, "reduction": 2, "name": "feature.1"},
+            {"chs": 8, "reduction": 4, "name": "feature.2"},
+        ]
+        self.flatten_sequential = True
+
+    def forward_features(self, x):
+        x = self.feature(x)
+        return x
+
+    def forward_multi_features(self, x):
+        x1 = self.feature[0](x)
+        x2 = self.feature[1](x1)
+        x3 = self.feature[2](x2)
+        return [x1, x2, x3]
+
+    def construct(self, x):
+        return self.forward_features(x)
+
+
+@pytest.mark.parametrize("mode", [0, 1])
+def test_feature_extraction_result_using_feature_wrapper():
+    np.random.seed(0)
+
+    net = SimpleCNN()
+    x = ms.Tensor(np.random.randn(8, 1, 32, 32), dtype=ms.float32)
+    y0 = net.forward_multi_features(x)
+
+    wrapped_net = FeatureExtractWrapper(net, [0, 1, 2])
+    y1 = wrapped_net(x)
+
+    assert len(y0) == len(y1)
+    assert len(y1) == 3
+    for z0, z1 in zip(y0, y1):
+        np.testing.assert_equal(z1.asnumpy(), z0.asnumpy())
+
+
+@pytest.mark.parametrize("mode", [0, 1])
+def test_feature_extraction_result_using_feature_wrapper_with_flatten_sequential():
+    np.random.seed(0)
+
+    net = SimpleCNNWithInnerSequential()
+    x = ms.Tensor(np.random.randn(8, 1, 32, 32), dtype=ms.float32)
+    y0 = net.forward_multi_features(x)
+
+    wrapped_net = FeatureExtractWrapper(net, [0, 1, 2])
+    y1 = wrapped_net(x)
+
+    assert len(y0) == len(y1)
+    assert len(y1) == 3
+    for z0, z1 in zip(y0, y1):
+        np.testing.assert_equal(z1.asnumpy(), z0.asnumpy())
+
+
+@pytest.mark.parametrize("mode", [0, 1])
+def test_feature_extraction_indices_using_feature_wrapper():
+    np.random.seed(0)
+
+    net = SimpleCNN()
+    x = ms.Tensor(np.random.randn(8, 1, 32, 32), dtype=ms.float32)
+    wrapped_net = FeatureExtractWrapper(net, [0, 1, 2])
+    y0 = wrapped_net(x)
+    assert len(y0) == 3
+
+    wrapped_net2 = FeatureExtractWrapper(net, [1])
+    y1 = wrapped_net2(x)
+    assert len(y1) == 1
+
+    np.testing.assert_equal(y0[1].asnumpy(), y1[0].asnumpy())


### PR DESCRIPTION
`mindcv.create_model` supports two arguments "features_only" and "out_indices".

By setting "mindcv.create_model(features_only=True)". It will output the features at multi-scales instead. 

Example:
```
>>> import numpy as np
>>> import mindspore as ms
>>> import mindcv
>>>
>>> network = mindcv.create_model("resnet50", pretrained=True, features_only=True, out_indices=[1, 2, 3, 4])
>>> x = ms.Tensor(np.zeros((8, 3, 224, 224)), dtype=ms.float32)
>>> y = network(x)
>>> for z in y:
>>>     print(z.shape)
(8, 256, 56, 56)
(8, 512, 28, 28)
(8, 1024, 14, 14)
(8, 2048, 7, 7)
```

The multi-scale feature pyramid are usually required by the downstream tasks such as detection, OCR, segmentation, etc.

Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

The change is based on requirement from MindOCR project.

## Test Plan

The functionality of the main components can be tested by [tests/modules/test_feature_extraction.py]

## Related Issues and PRs

#434 