### PR TITLE
support gradient accumulation function

### DIFF
--- a/config.py
+++ b/config.py
@@ -160,6 +160,8 @@ def create_parser():
                        help='Whether use clip grad (default=False)')
     group.add_argument('--clip_value', type=float, default=15.0,
                        help='Clip value (default=15.0)')
+    group.add_argument('--accumulate_grad_batches', type=int, default=1,
+                       help="Accumulate the gradients of n batches before update.")
 
     # Optimize parameters
     group = parser.add_argument_group('Optimizer parameters')

--- a/config.py
+++ b/config.py
@@ -160,7 +160,7 @@ def create_parser():
                        help='Whether use clip grad (default=False)')
     group.add_argument('--clip_value', type=float, default=15.0,
                        help='Clip value (default=15.0)')
-    group.add_argument('--accumulate_grad_batches', type=int, default=1,
+    group.add_argument('--gradient_accumulation_steps', type=int, default=1,
                        help="Accumulate the gradients of n batches before update.")
 
     # Optimize parameters

--- a/mindcv/utils/__init__.py
+++ b/mindcv/utils/__init__.py
@@ -3,6 +3,7 @@ from .amp import *
 from .callbacks import *
 from .checkpoint_manager import *
 from .download import *
+from .gradient_accumulation import *
 from .path import *
 from .random import *
 from .reduce_manager import *

--- a/mindcv/utils/gradient_accumulation.py
+++ b/mindcv/utils/gradient_accumulation.py
@@ -1,0 +1,72 @@
+from mindspore.common import Parameter, Tensor
+from mindspore.common import dtype as mstype
+from mindspore.nn.cell import Cell
+from mindspore.ops import composite as C
+from mindspore.ops import functional as F
+from mindspore.ops import operations as P
+
+__all__ = ["GradientAccumulation", "gradient_accumulation_op", "gradient_clear_op"]
+
+
+gradient_accumulation_op = C.MultitypeFuncGraph("gradient_accumulation_op")
+
+
+@gradient_accumulation_op.register("Int64", "Tensor", "Tensor")
+def cumulative_grad_process(accumulation_step, cumulative_grad, grad):
+    """Apply gradient accumulation to cumulative grad."""
+    return P.AssignAdd()(cumulative_grad, grad / accumulation_step)
+
+
+gradient_clear_op = C.MultitypeFuncGraph("gradient_clear_op")
+
+
+@gradient_clear_op.register("Tensor")
+def clear_grad(cumulative_grad):
+    """Clear grad."""
+    zero_grad = P.ZerosLike()(cumulative_grad)
+    return F.assign(cumulative_grad, zero_grad)
+
+
+class GradientAccumulation(Cell):
+    """
+    After accumulating the gradients of multiple steps, call to optimize its update.
+
+    Args:
+       max_accumulation_step (int): Steps to accumulate gradients.
+       optimizer (Cell): Optimizer used.
+    """
+
+    def __init__(self, max_accumulation_step, optimizer, grad_reducer):
+        super(GradientAccumulation, self).__init__()
+        self._max_accumulation_step = max_accumulation_step
+        self.optimizer = optimizer
+        self.weights = optimizer.parameters
+        self.hyper_map = C.HyperMap()
+        self.grad_reducer = grad_reducer
+        self._grad_accumulation = self.weights.clone(prefix="grad_accumulation", init="zeros")
+        self._accumulation_step = Parameter(Tensor(0, dtype=mstype.int32), name="accumulation_step")
+
+    def construct(self, loss, grads, overflow):
+        # do not accumulate the grad it it is overflow
+        if overflow:
+            return loss
+
+        loss = F.depend(
+            loss,
+            self.hyper_map(
+                F.partial(gradient_accumulation_op, self._max_accumulation_step), self._grad_accumulation, grads
+            ),
+        )
+        self._accumulation_step += 1
+
+        if self._accumulation_step >= self._max_accumulation_step:
+            # accumulate the gradient at each device, don't sync them until updating the weight
+            reduced_grad_accumulation = self.grad_reducer(self._grad_accumulation)
+            loss = F.depend(loss, self.optimizer(reduced_grad_accumulation))
+            loss = F.depend(loss, self.hyper_map(F.partial(gradient_clear_op), self._grad_accumulation))
+            self._accumulation_step = 0
+        else:
+            # update the learning rate, do not update the parameter
+            loss = F.depend(loss, self.optimizer.get_lr())
+
+        return loss

--- a/mindcv/utils/train_step.py
+++ b/mindcv/utils/train_step.py
@@ -50,7 +50,7 @@ class TrainStep(nn.TrainOneStepWithLossScaleCell):
         updates=0,
         clip_grad=False,
         clip_value=15.0,
-        accumulate_grad_batches=1,
+        gradient_accumulation_steps=1,
     ):
         super(TrainStep, self).__init__(network, optimizer, scale_sense)
         self.ema = ema
@@ -62,9 +62,9 @@ class TrainStep(nn.TrainOneStepWithLossScaleCell):
             self.weights_all = ms.ParameterTuple(list(network.get_parameters()))
             self.ema_weight = self.weights_all.clone("ema", init="same")
 
-        self.need_accumulate_grad = accumulate_grad_batches > 1
+        self.need_accumulate_grad = gradient_accumulation_steps > 1
         if self.need_accumulate_grad:
-            self.gradient_accumulation = GradientAccumulation(accumulate_grad_batches, optimizer, self.grad_reducer)
+            self.gradient_accumulation = GradientAccumulation(gradient_accumulation_steps, optimizer, self.grad_reducer)
 
     def ema_update(self):
         """Update EMA parameters."""

--- a/mindcv/utils/trainer_factory.py
+++ b/mindcv/utils/trainer_factory.py
@@ -28,12 +28,14 @@ def get_metrics(num_classes):
     return metrics
 
 
-def _require_customized_train_step(ema: bool = False, clip_grad: bool = False, accumulate_grad_batches: bool = False):
+def _require_customized_train_step(
+    ema: bool = False, clip_grad: bool = False, gradient_accumulation_steps: bool = False
+):
     if ema:
         return True
     if clip_grad:
         return True
-    if accumulate_grad_batches > 1:
+    if gradient_accumulation_steps > 1:
         return True
     return False
 
@@ -51,7 +53,7 @@ def create_trainer(
     ema_decay: float = 0.9999,
     clip_grad: bool = False,
     clip_value: float = 15.0,
-    accumulate_grad_batches: int = 1,
+    gradient_accumulation_steps: int = 1,
 ):
     """Create Trainer.
 
@@ -68,7 +70,7 @@ def create_trainer(
         ema_decay: Decay factor for model weights moving average.
         clip_grad: whether to gradient clip.
         clip_value: The value at which to clip gradients.
-        accumulate_grad_batches: Accumulate the gradients of n batches before update.
+        gradient_accumulation_steps: Accumulate the gradients of n batches before update.
 
     Returns:
         mindspore.Model
@@ -80,10 +82,10 @@ def create_trainer(
     if drop_overflow_update is False and loss_scale_type.lower() == "dynamic":
         raise ValueError("DynamicLossScale ALWAYS drop overflow!")
 
-    if accumulate_grad_batches < 1:
-        raise ValueError("`accumulate_grad_batches` must be >= 1!")
+    if gradient_accumulation_steps < 1:
+        raise ValueError("`gradient_accumulation_steps` must be >= 1!")
 
-    if not _require_customized_train_step(ema, clip_grad, accumulate_grad_batches):
+    if not _require_customized_train_step(ema, clip_grad, gradient_accumulation_steps):
         mindspore_kwargs = dict(
             network=network,
             loss_fn=loss,
@@ -119,7 +121,7 @@ def create_trainer(
             ema_decay=ema_decay,
             clip_grad=clip_grad,
             clip_value=clip_value,
-            accumulate_grad_batches=accumulate_grad_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
         )
         if loss_scale_type.lower() == "fixed":
             # todo: drop_overflow_update. If drop_overflow_update is False, scale_sense should be a number

--- a/train.py
+++ b/train.py
@@ -224,6 +224,7 @@ def train(args):
         ema_decay=args.ema_decay,
         clip_grad=args.clip_grad,
         clip_value=args.clip_value,
+        accumulate_grad_batches=args.accumulate_grad_batches,
     )
 
     # callback

--- a/train.py
+++ b/train.py
@@ -224,7 +224,7 @@ def train(args):
         ema_decay=args.ema_decay,
         clip_grad=args.clip_grad,
         clip_value=args.clip_value,
-        accumulate_grad_batches=args.accumulate_grad_batches,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
     )
 
     # callback


### PR DESCRIPTION
`train.py` supports `accumulate_grad_batches` arguments, which allow the gradient to be accumulated for N steps before performing weight update. So, the model training with a `batch size = N` and `accumulate_grad_batches = 1` is effectively same as a `batch size = N / M` with  `accumulate_grad_batches = M`. Details can be found in [gradient_accumulation](https://www.mindspore.cn/tutorials/experts/en/r1.10/others/gradient_accumulation.html).

The implementation of this PR is based on [mindspore.boost.GradientAccumulation](https://www.mindspore.cn/docs/en/r1.9/_modules/mindspore/boost/grad_accumulation.html#GradientAccumulation) with the following modifications:
1. We have added a overflow check in gradient accumulation. The overflowed gradient at the training step will be skipped.  The overflow is commonly happened in mixed-precision training.
2. The learning rate will be updated at each iteration step. However, in the original implementation, the learning rate will only be updated for each M iteration steps.
3. For distributed training, at gradient accumulation stage, each devices will maintain its own accumulated gradient; At the parameter update stage, the gradient will be synchronized across the devices first and then perform the gradient update.

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

Large model may need gradient accumulation due to the limitation of the device memory.

## Test Plan

The functionality can be tested using `test_gradient_accumulation` at `tests/modules/non_cpu/test_utils.py`

## Related Issues and PRs

#595 
