### PR TITLE
Fix vit when pooling mode is not cls.

### DIFF
--- a/mindcv/models/vit.py
+++ b/mindcv/models/vit.py
@@ -600,7 +600,7 @@ class ViT(nn.Cell):
         if self.pool == "cls":
             x = x[:, 0]
         else:
-            x = self.mean(x, (1, 2))  # (1,) or (1,2)
+            x = self.mean(x, (1, ))  # (1,) or (1,2)
         return x
 
 


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

by default pooling mode is cls in vit, when changed to mean, the dimension will be wrong. fixed in this pr.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
