### PR TITLE
[Feature] add training recipe and trained weights of Repvgg

### DIFF
--- a/configs/repvgg/README.md
+++ b/configs/repvgg/README.md
@@ -32,15 +32,18 @@ Our reproduced model performance on ImageNet-1K is reported as follows.
 
 <div align="center">
 
-| Model     | Context   | Top-1 (%) | Top-5 (%) | Params (M) | Recipe                                                                                         | Download                                                           |
-|-----------|-----------|-----------|-----------|------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| repvgg_a0 | D910x8-G  | 72.19     | 90.75     | 9.13       | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a0_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a0-6e71139d.ckpt) |
-| repvgg_a1 | D910x8-G  | 74.19     | 91.89     | 14.12      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a1_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a1-539513ac.ckpt) |
-| repvgg_a2 | D910x8-G  | 76.63     | 93.42     | 28.25      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a2_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a2-cdc90b11.ckpt) |
-| repvgg_b0 | D910x8-G  | 74.99     | 92.40     | 15.85      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b0_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b0-54d5862c.ckpt) |
-| repvgg_b1 | D910x8-G  | 78.81     | 94.37     | 57.48      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b1_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1-4673797.ckpt) |
-| repvgg_b2 | D910x64-G | 79.29     | 94.66     | 89.11      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b2_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b2-7c91ccd4.ckpt) |
-| repvgg_b3 | D910x64-G | 80.46     | 95.34     | 123.19     | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b3_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b3-30b35f52.ckpt) |
+| Model       | Context   | Top-1 (%) | Top-5 (%) | Params (M) | Recipe                                                                                           | Download                                                                                  |
+|-------------|-----------|-----------|-----------|------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| repvgg_a0   | D910x8-G  | 72.19     | 90.75     | 9.13       | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a0_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a0-6e71139d.ckpt)   |
+| repvgg_a1   | D910x8-G  | 74.19     | 91.89     | 14.12      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a1_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a1-539513ac.ckpt)   |
+| repvgg_a2   | D910x8-G  | 76.63     | 93.42     | 28.25      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_a2_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_a2-cdc90b11.ckpt)   |
+| repvgg_b0   | D910x8-G  | 74.99     | 92.40     | 15.85      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b0_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b0-54d5862c.ckpt)   |
+| repvgg_b1   | D910x8-G  | 78.81     | 94.37     | 57.48      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b1_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1-4673797.ckpt)    |
+| repvgg_b2   | D910x64-G | 79.29     | 94.66     | 89.11      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b2_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b2-7c91ccd4.ckpt)   |
+| repvgg_b3   | D910x64-G | 80.46     | 95.34     | 123.19     | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b3_ascend.yaml)   | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b3-30b35f52.ckpt)   |
+| repvgg_b1g2 | D910x8-G  | 78.03     | 94.09     | 45.85      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b1g2_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1g2-f0dc714f.ckpt) |
+| repvgg_b1g4 | D910x8-G  | 80.46     | 95.34     | 40.03      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b1g4_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1g4-bd93230e.ckpt) |
+| repvgg_b2g4 | D910x8-G  | 78.8      | 94.36     | 61.84      | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/repvgg/repvgg_b2g4_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b2g4-e79eeadd.ckpt) |
 
 </div>
 

--- a/configs/repvgg/repvgg_b1g2_ascend.yaml
+++ b/configs/repvgg/repvgg_b1g2_ascend.yaml
@@ -1,0 +1,52 @@
+# system
+mode: 0
+distribute: True
+num_parallel_workers: 8
+val_while_train: True
+
+# dataset
+dataset: "imagenet"
+data_dir: "/path/to/imagenet"
+shuffle: True
+dataset_download: False
+batch_size: 32
+drop_remainder: True
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+interpolation: "bicubic"
+crop_pct: 0.875
+
+# model
+model: "repvgg_b1g2"
+num_classes: 1000
+pretrained: False
+ckpt_path: ""
+keep_checkpoint_max: 10
+ckpt_save_dir: "./ckpt"
+epoch_size: 240
+dataset_sink_mode: True
+amp_level: "O2"
+
+# loss
+loss: "CE"
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: "warmup_cosine_decay"
+lr: 0.05
+warmup_epochs: 5
+decay_epochs: 235
+
+# optimizer
+opt: "momentum"
+filter_bias_and_bn: True
+momentum: 0.9
+weight_decay: 0.0001
+loss_scale_type: "dynamic"
+drop_overflow_update: True
+use_nesterov: False
+eps: 0.00000001

--- a/configs/repvgg/repvgg_b1g4_ascend.yaml
+++ b/configs/repvgg/repvgg_b1g4_ascend.yaml
@@ -1,0 +1,52 @@
+# system
+mode: 0
+distribute: True
+num_parallel_workers: 8
+val_while_train: True
+
+# dataset
+dataset: "imagenet"
+data_dir: "/path/to/imagenet"
+shuffle: True
+dataset_download: False
+batch_size: 32
+drop_remainder: True
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+interpolation: "bicubic"
+crop_pct: 0.875
+
+# model
+model: "repvgg_b1g4"
+num_classes: 1000
+pretrained: False
+ckpt_path: ""
+keep_checkpoint_max: 10
+ckpt_save_dir: "./ckpt"
+epoch_size: 240
+dataset_sink_mode: True
+amp_level: "O2"
+
+# loss
+loss: "CE"
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: "cosine_decay"
+lr: 0.05
+warmup_epochs: 5
+decay_epochs: 235
+
+# optimizer
+opt: "momentum"
+filter_bias_and_bn: True
+momentum: 0.9
+weight_decay: 0.0001
+loss_scale_type: "dynamic"
+drop_overflow_update: True
+use_nesterov: False
+eps: 0.00000001

--- a/configs/repvgg/repvgg_b2g4_ascend.yaml
+++ b/configs/repvgg/repvgg_b2g4_ascend.yaml
@@ -1,0 +1,52 @@
+# system
+mode: 0
+distribute: True
+num_parallel_workers: 8
+val_while_train: True
+
+# dataset
+dataset: "imagenet"
+data_dir: "/path/to/imagenet"
+shuffle: True
+dataset_download: False
+batch_size: 32
+drop_remainder: True
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+interpolation: "bilinear"
+crop_pct: 0.875
+
+# model
+model: "repvgg_b2g4"
+num_classes: 1000
+pretrained: False
+ckpt_path: ""
+keep_checkpoint_max: 10
+ckpt_save_dir: "./ckpt"
+epoch_size: 240
+dataset_sink_mode: True
+amp_level: "O2"
+
+# loss
+loss: "CE"
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: "cosine_decay"
+lr: 0.05
+warmup_epochs: 5
+decay_epochs: 235
+
+# optimizer
+opt: "momentum"
+filter_bias_and_bn: True
+momentum: 0.9
+weight_decay: 0.0001
+loss_scale_type: "dynamic"
+drop_overflow_update: True
+use_nesterov: False
+eps: 0.00000001

--- a/mindcv/models/repvgg.py
+++ b/mindcv/models/repvgg.py
@@ -23,6 +23,9 @@ __all__ = [
     "repvgg_b1",
     "repvgg_b2",
     "repvgg_b3",
+    "repvgg_b1g2",
+    "repvgg_b1g4",
+    "repvgg_b2g4"
 ]
 
 
@@ -44,6 +47,9 @@ default_cfgs = {
     "repvgg_b1": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1-4673797.ckpt"),
     "repvgg_b2": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b2-7c91ccd4.ckpt"),
     "repvgg_b3": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b3-30b35f52.ckpt"),
+    "repvgg_b1g2": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1g2-f0dc714f.ckpt"),
+    "repvgg_b1g4": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b1g4-bd93230e.ckpt"),
+    "repvgg_b2g4": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/repvgg/repvgg_b2g4-e79eeadd.ckpt"),
 }
 
 
@@ -60,6 +66,7 @@ def conv_bn(in_channels: int, out_channels: int, kernel_size: int,
 
 class RepVGGBlock(nn.Cell):
     """Basic Block of RepVGG"""
+
     def __init__(self, in_channels: int, out_channels: int, kernel_size: int,
                  stride: int = 1, padding: int = 0, dilation: int = 1,
                  group: int = 1, padding_mode: str = "zeros",
@@ -120,9 +127,9 @@ class RepVGGBlock(nn.Cell):
               ((self.rbr_1x1.bn.moving_variance + self.rbr_1x1.bn.eps).sqrt()))
         t1 = ops.reshape(t1, (-1, 1, 1, 1))
 
-        l2_loss_circle = ops.reduce_sum(k3**2) - ops.reduce_sum(k3[:, :, 1:2, 1:2] ** 2)
+        l2_loss_circle = ops.reduce_sum(k3 ** 2) - ops.reduce_sum(k3[:, :, 1:2, 1:2] ** 2)
         eq_kernel = k3[:, :, 1:2, 1:2] * t3 + k1 * t1
-        l2_loss_eq_kernel = ops.reduce_sum(eq_kernel**2 / (t3**2 + t1**2))
+        l2_loss_eq_kernel = ops.reduce_sum(eq_kernel ** 2 / (t3 ** 2 + t1 ** 2))
         return l2_loss_eq_kernel + l2_loss_circle
 
     #   This func derives the equivalent kernel and bias in a DIFFERENTIABLE way.
@@ -378,6 +385,53 @@ def repvgg_b3(pretrained: bool = False, num_classes: int = 1000, in_channels=3, 
     if pretrained:
         load_pretrained(model, default_cfg,
                         num_classes=num_classes, in_channels=in_channels)
+
+    return model
+
+
+optional_groupwise_layers = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26]
+g2_map = {g_layer: 2 for g_layer in optional_groupwise_layers}
+g4_map = {g_layer: 4 for g_layer in optional_groupwise_layers}
+
+
+@register_model
+def repvgg_b1g2(pretrained: bool = False, num_classes: int = 1000, in_channels=3, **kwargs) -> RepVGG:
+    """Get RepVGG model with num_blocks=[4, 6, 16, 1], width_multiplier=[2.0, 2.0, 2.0, 4.0].
+    Refer to the base class `models.RepVGG` for more details.
+    """
+    default_cfg = default_cfgs["repvgg_b1g2"]
+    model = RepVGG(num_blocks=[4, 6, 16, 1], num_classes=num_classes, in_channels=in_channels,
+                   width_multiplier=[2.0, 2.0, 2.0, 4.0], override_group_map=g2_map, deploy=False, **kwargs)
+    if pretrained:
+        load_pretrained(model, default_cfg, num_classes=num_classes, in_channels=in_channels)
+
+    return model
+
+
+@register_model
+def repvgg_b1g4(pretrained: bool = False, num_classes: int = 1000, in_channels=3, **kwargs) -> RepVGG:
+    """Get RepVGG model with num_blocks=[4, 6, 16, 1], width_multiplier=[2.0, 2.0, 2.0, 4.0].
+    Refer to the base class `models.RepVGG` for more details.
+    """
+    default_cfg = default_cfgs["repvgg_b1g4"]
+    model = RepVGG(num_blocks=[4, 6, 16, 1], num_classes=num_classes, in_channels=in_channels,
+                   width_multiplier=[2.0, 2.0, 2.0, 4.0], override_group_map=g4_map, deploy=False, **kwargs)
+    if pretrained:
+        load_pretrained(model, default_cfg, num_classes=num_classes, in_channels=in_channels)
+
+    return model
+
+
+@register_model
+def repvgg_b2g4(pretrained: bool = False, num_classes: int = 1000, in_channels=3, **kwargs) -> RepVGG:
+    """Get RepVGG model with num_blocks=[4, 6, 16, 1], width_multiplier=[2.5, 2.5, 2.5, 5.0].
+    Refer to the base class `models.RepVGG` for more details.
+    """
+    default_cfg = default_cfgs["repvgg_b2g4"]
+    model = RepVGG(num_blocks=[4, 6, 16, 1], num_classes=num_classes, in_channels=in_channels,
+                   width_multiplier=[2.5, 2.5, 2.5, 5.0], override_group_map=g4_map, deploy=False, **kwargs)
+    if pretrained:
+        load_pretrained(model, default_cfg, num_classes=num_classes, in_channels=in_channels)
 
     return model
 


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

This PR is proposed to add training recipe and trained weights of repvgg_b1g2, repvgg_b1g4, repvgg_b2g4.

## Test Plan

Please refer to "configs/repvgg/README.md" for testing and reproducing.

## Related Issues and PRs

Related issue: https://github.com/mindspore-lab/mindcv/issues/436
Related PR: https://github.com/mindspore-lab/mindcv/pull/560, https://github.com/mindspore-lab/mindcv/pull/579