### PR TITLE
feat: add training recipe & pretrained weights of regnet_(x,y)_(2,4,6,8)00mf

### DIFF
--- a/configs/regnet/README.md
+++ b/configs/regnet/README.md
@@ -16,7 +16,14 @@ Our reproduced model performance on ImageNet-1K is reported as follows.
 
 |     Model      | Context  | Top-1 (%) | Top-5 (%) | Params (M) | Recipe                                                                                              | Download                                                                                     |
 |:--------------:|:--------:|:---------:|:---------:|:----------:|-----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| regnet_x_200mf | D910x8-G |   68.74   |   88.38   |    2.68    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_x_200mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_200mf-0c2b1eb5.ckpt) |
+| regnet_x_400mf | D910x8-G |   73.16   |   91.35   |    5.16    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_x_400mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_400mf-4848837d.ckpt) |
+| regnet_x_600mf | D910x8-G |   74.34   |   92.00   |    6.20    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_x_600mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_600mf-ccd76c94.ckpt) |
 | regnet_x_800mf | D910x8-G |   76.04   |   92.97   |    7.26    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_x_800mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_800mf-617227f4.ckpt) |
+| regnet_y_200mf | D910x8-G |   70.30   |   89.61   |    3.16    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_y_200mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_200mf-76a2f720.ckpt) |
+| regnet_y_400mf | D910x8-G |   73.91   |   91.84   |    4.34    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_y_400mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_400mf-d496799d.ckpt) |
+| regnet_y_600mf | D910x8-G |   75.69   |   92.50   |    6.06    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_y_600mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_600mf-a84e19b2.ckpt) |
+| regnet_y_800mf | D910x8-G |   76.52   |   93.10   |    6.26    | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/regnet/regnet_y_800mf_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_800mf-9b5211bd.ckpt) |
 
 </div>
 

--- a/configs/regnet/regnet_x_200mf_ascend.yaml
+++ b/configs/regnet/regnet_x_200mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_x_200mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_x_400mf_ascend.yaml
+++ b/configs/regnet/regnet_x_400mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_x_400mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_x_600mf_ascend.yaml
+++ b/configs/regnet/regnet_x_600mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_x_600mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_y_200mf_ascend.yaml
+++ b/configs/regnet/regnet_y_200mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_y_200mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_y_400mf_ascend.yaml
+++ b/configs/regnet/regnet_y_400mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_y_400mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_y_600mf_ascend.yaml
+++ b/configs/regnet/regnet_y_600mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_y_600mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/configs/regnet/regnet_y_800mf_ascend.yaml
+++ b/configs/regnet/regnet_y_800mf_ascend.yaml
@@ -1,0 +1,56 @@
+# system
+mode: 0
+distribute: True
+val_while_train: True
+val_interval: 1
+log_interval: 100
+
+# dataset
+dataset: 'imagenet'
+data_dir: '/path/to/imagenet'
+shuffle: True
+num_parallel_workers: 8
+batch_size: 64
+
+# augmentation
+image_resize: 224
+scale: [0.08, 1.0]
+ratio: [0.75, 1.333]
+hflip: 0.5
+vflip: 0.0
+interpolation: 'bicubic'
+color_jitter: 0.4
+re_prob: 0.1
+
+# model
+model: 'regnet_y_800mf'
+num_classes: 1000
+keep_checkpoint_max: 10
+ckpt_save_dir: './ckpt'
+ckpt_save_interval: 1
+ckpt_save_policy: 'latest_k'
+epoch_size: 150
+dataset_sink_mode: True
+
+# loss
+loss: 'CE'
+label_smoothing: 0.1
+
+# lr scheduler
+scheduler: 'cosine_decay'
+min_lr: 0.0
+lr: 0.1
+warmup_epochs: 5
+warmup_factor: 0.01
+decay_epochs: 145
+
+# optimizer
+opt: 'momentum'
+momentum: 0.9
+weight_decay: 5e-5
+use_nesterov: False
+filter_bias_and_bn: True
+
+# amp
+amp_level: 'O2'
+loss_scale_type: 'auto'

--- a/mindcv/models/regnet.py
+++ b/mindcv/models/regnet.py
@@ -54,9 +54,9 @@ def _cfg(url="", **kwargs):
 
 
 default_cfgs = {
-    "regnet_x_200mf": _cfg(url=""),
-    "regnet_x_400mf": _cfg(url=""),
-    "regnet_x_600mf": _cfg(url=""),
+    "regnet_x_200mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_200mf-0c2b1eb5.ckpt"),
+    "regnet_x_400mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_400mf-4848837d.ckpt"),
+    "regnet_x_600mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_600mf-ccd76c94.ckpt"),
     "regnet_x_800mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_x_800mf-617227f4.ckpt"),
     "regnet_x_1_6gf": _cfg(url=""),
     "regnet_x_3_2gf": _cfg(url=""),
@@ -66,10 +66,10 @@ default_cfgs = {
     "regnet_x_12gf": _cfg(url=""),
     "regnet_x_16gf": _cfg(url=""),
     "regnet_x_32gf": _cfg(url=""),
-    "regnet_y_200mf": _cfg(url=""),
-    "regnet_y_400mf": _cfg(url=""),
-    "regnet_y_600mf": _cfg(url=""),
-    "regnet_y_800mf": _cfg(url=""),
+    "regnet_y_200mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_200mf-76a2f720.ckpt"),
+    "regnet_y_400mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_400mf-d496799d.ckpt"),
+    "regnet_y_600mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_600mf-a84e19b2.ckpt"),
+    "regnet_y_800mf": _cfg(url="https://download.mindspore.cn/toolkits/mindcv/regnet/regnet_y_800mf-9b5211bd.ckpt"),
     "regnet_y_1_6gf": _cfg(url=""),
     "regnet_y_3_2gf": _cfg(url=""),
     "regnet_y_4_0gf": _cfg(url=""),
@@ -494,7 +494,6 @@ class RegNet(AnyNet):
                  block_type="res_bottleneck_block", head_w=0, num_classes=1000, se_r=0.0, in_channels=3):
         params = RegNet.regnet_get_params(w_a, w_0, w_m, d, stride, bot_mul, group_w, stem_type, stem_w, block_type,
                                           head_w, num_classes, se_r)
-        print(params)
         super(RegNet, self).__init__(params["depths"], params["stem_type"], params["stem_w"], params["block_type"],
                                      params["widths"], params["strides"], params["bot_muls"], params["group_ws"],
                                      params["head_w"], params["num_classes"], params["se_r"], in_channels)


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)
Add training recipe and pretrained weights of `regnet_x_200mf`, `regnet_x_400mf`, `regnet_x_600mf`, `regnet_y_200mf`, `regnet_y_400mf`, `regnet_y_600mf`, `regnet_y_800mf`.

In fact, the models of these scalings use a unified training recipe. We envisioned training all scalings of `RegNet` using this unified training recipe, but some scalings failed to train. This leaves us with follow-up work.

`regnet_x_800mf` keeps using old recipe for better performance.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)
No need.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
