### PR TITLE
[WIP] feat: upgrade ms to v2.0 while maintaining compatibility of v1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,9 @@ dmypy.json
 # IDEs
 .idea/
 .vscode/
+
+# outputs
+rank_*/
+ckpt/
+output/
+outputs/

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ In contrast, [pynative mode](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advan
 
 **Mixed Mode**:
 
-[Pynative mode with ms_function ](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) is a mixed mode for comprising flexibility and efficiency in MindSpore. To apply pynative mode with ms_function for training, please run `train_with_func.py`, e.g.,
+[PyNative mode with mindspore.jit](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) is a mixed mode for comprising flexibility and efficiency in MindSpore. To apply pynative mode with mindspore.jit for training, please run `train_with_func.py`, e.g.,
 
 ```shell
 python train_with_func.py --model=resnet50 --dataset=cifar10 --dataset_download  --epoch_size=10

--- a/README_CN.md
+++ b/README_CN.md
@@ -157,7 +157,7 @@ MindCV是一个基于 [MindSpore](https://www.mindspore.cn/) 开发的，致力�
 
 **混合模式**
 
-[基于ms_function的混合模式](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) 是兼顾了MindSpore的效率和灵活的混合模式。用户可通过使用`train_with_func.py`文件来使用该混合模式进行训练。
+[基于mindspore.jit的混合模式](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) 是兼顾了MindSpore的效率和灵活的混合模式。用户可通过使用`train_with_func.py`文件来使用该混合模式进行训练。
 
 ```shell
 python train_with_func.py --model=resnet50 --dataset=cifar10 --dataset_download --epoch_size=10

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -154,7 +154,7 @@ It is easy to train your model on a standard or customized dataset using `train.
 
 !!! warning "Mixed Mode"
 
-    [Pynative mode with ms_function](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) is a mixed mode for comprising flexibility and efficiency in MindSpore. To apply pynative mode with ms_function for training, please run `train_with_func.py`, e.g.,
+    [PyNative mode with mindspore.jit](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) is a mixed mode for comprising flexibility and efficiency in MindSpore. To apply pynative mode with mindspore.jit for training, please run `train_with_func.py`, e.g.,
 
     ```shell
     python train_with_func.py --model=resnet50 --dataset=cifar10 --dataset_download  --epoch_size=10

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -153,7 +153,7 @@ MindCV是一个基于 [MindSpore](https://www.mindspore.cn/) 开发的，致力�
 
 !!! warning "混合模式"
 
-    [基于ms_function的混合模式](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) 是兼顾了MindSpore的效率和灵活的混合模式。用户可通过使用`train_with_func.py`文件来使用该混合模式进行训练。
+    [基于mindspore.jit的混合模式](https://www.mindspore.cn/tutorials/zh-CN/r1.8/advanced/pynative_graph/combine.html) 是兼顾了MindSpore的效率和灵活的混合模式。用户可通过使用`train_with_func.py`文件来使用该混合模式进行训练。
 
     ```shell
     python train_with_func.py --model=resnet50 --dataset=cifar10 --dataset_download --epoch_size=10

--- a/examples/train_with_func_example.py
+++ b/examples/train_with_func_example.py
@@ -12,6 +12,11 @@ from mindcv.loss import create_loss
 from mindcv.models import create_model
 from mindcv.optim import create_optimizer
 
+try:
+    from mindspore import jit
+except ImportError:
+    from mindspore import ms_function as jit
+
 
 def main():
     ms.set_seed(1)
@@ -96,7 +101,7 @@ def train_epoch(network, dataset, loss_fn, optimizer):
     grad_fn = ops.value_and_grad(forward_fn, None, optimizer.parameters, has_aux=True)
 
     # Define function of one-step training,
-    @ms.ms_function
+    @jit
     def train_step(data, label):
         (loss, _), grads = grad_fn(data, label)
         loss = ops.depend(loss, optimizer(grads))

--- a/mindcv/models/cait.py
+++ b/mindcv/models/cait.py
@@ -13,6 +13,7 @@ from mindspore import Parameter, Tensor
 from mindspore.common.initializer import TruncatedNormal
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.drop_path import DropPath
 from .layers.mlp import Mlp
 from .layers.patch_embed import PatchEmbed
@@ -41,12 +42,12 @@ def _cfg(url='', **kwargs):
 
 default_cfgs = {
     "cait_xxs24_224": _cfg(url=''),
-    "cait_xs24_384": _cfg(url=''),
+    "cait_xs24_384": _cfg(url='', input_size=(3, 384, 384)),
     "cait_s24_224": _cfg(url=''),
-    "cait_s24_384": _cfg(url=''),
-    "cait_s36_384": _cfg(url=''),
-    "cait_m36_384": _cfg(url=''),
-    "cait_m48_448": _cfg(url=''),
+    "cait_s24_384": _cfg(url='', input_size=(3, 384, 384)),
+    "cait_s36_384": _cfg(url='', input_size=(3, 384, 384)),
+    "cait_m36_384": _cfg(url='', input_size=(3, 384, 384)),
+    "cait_m48_448": _cfg(url='', input_size=(3, 448, 448)),
 }
 
 
@@ -67,9 +68,9 @@ class ClassAttention(nn.Cell):
         self.q = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.k = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.v = nn.Dense(dim, dim, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1 - attn_drop_rate)
+        self.attn_drop = Dropout(p=attn_drop_rate)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(1 - proj_drop_rate)
+        self.proj_drop = Dropout(p=proj_drop_rate)
         self.softmax = nn.Softmax(axis=-1)
 
         self.attn_matmul_v = ops.BatchMatMul()
@@ -156,14 +157,14 @@ class AttentionTalkingHead(nn.Cell):
         self.scale = qk_scale or head_dim ** -0.5
 
         self.qkv = nn.Dense(dim, dim * 3, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1 - attn_drop_rate)
+        self.attn_drop = Dropout(p=attn_drop_rate)
 
         self.proj = nn.Dense(dim, dim, has_bias=False)
 
         self.proj_l = nn.Dense(num_heads, num_heads, has_bias=False)
         self.proj_w = nn.Dense(num_heads, num_heads, has_bias=False)
 
-        self.proj_drop = nn.Dropout(1 - proj_drop_rate)
+        self.proj_drop = Dropout(p=proj_drop_rate)
 
         self.softmax = nn.Softmax(axis=-1)
 
@@ -271,7 +272,7 @@ class CaiT(nn.Cell):
         zeros = ops.Zeros()
         self.cls_token = Parameter(zeros((1, 1, embed_dim), ms.float32))
         self.pos_embed = Parameter(zeros((1, num_patches, embed_dim), ms.float32))
-        self.pos_drop = nn.Dropout(1 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
 
         dpr = [drop_path_rate for i in range(depth)]
 

--- a/mindcv/models/convit.py
+++ b/mindcv/models/convit.py
@@ -11,6 +11,7 @@ from mindspore import Parameter, Tensor, nn, ops
 from mindspore.ops import constexpr
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.drop_path import DropPath
 from .layers.identity import Identity
 from .layers.mlp import Mlp
@@ -85,10 +86,10 @@ class GPSA(nn.Cell):
         self.k = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
         self.v = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
 
-        self.attn_drop = nn.Dropout(keep_prob=1.0 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(in_channels=dim, out_channels=dim)
         self.pos_proj = nn.Dense(in_channels=3, out_channels=num_heads)
-        self.proj_drop = nn.Dropout(keep_prob=1.0 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.gating_param = Parameter(ops.ones((num_heads), ms.float32))
         self.softmax = nn.Softmax(axis=-1)
         self.batch_matmul = ops.BatchMatMul()
@@ -144,9 +145,9 @@ class MHSA(nn.Cell):
         self.q = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
         self.k = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
         self.v = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(keep_prob=1.0 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(in_channels=dim, out_channels=dim)
-        self.proj_drop = nn.Dropout(keep_prob=1.0 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.softmax = nn.Softmax(axis=-1)
         self.batch_matmul = ops.BatchMatMul()
 
@@ -261,7 +262,7 @@ class ConViT(nn.Cell):
         self.num_patches = self.patch_embed.num_patches
 
         self.cls_token = Parameter(ops.Zeros()((1, 1, embed_dim), ms.float32))
-        self.pos_drop = nn.Dropout(keep_prob=1.0 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
 
         if self.use_pos_embed:
             self.pos_embed = Parameter(ops.Zeros()((1, self.num_patches, embed_dim), ms.float32))

--- a/mindcv/models/crossvit.py
+++ b/mindcv/models/crossvit.py
@@ -14,6 +14,7 @@ from mindspore import dtype as mstype
 from mindspore.common.initializer import TruncatedNormal
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout, Interpolate
 from .layers.drop_path import DropPath
 from .layers.helpers import to_2tuple
 from .layers.identity import Identity
@@ -55,9 +56,9 @@ class Attention(nn.Cell):
         self.scale = head_dim ** -0.5
 
         self.qkv = nn.Dense(dim, dim * 3, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1.0 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(1.0 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
 
     def construct(self, x: Tensor) -> Tensor:
         B, N, C = x.shape
@@ -157,9 +158,9 @@ class CrossAttention(nn.Cell):
         self.wq = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.wk = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.wv = nn.Dense(dim, dim, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1.0 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(1.0 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
 
     def construct(self, x: Tensor) -> Tensor:
         B, N, C = x.shape  # 3,3,16
@@ -325,6 +326,7 @@ class VisionTransformer(nn.Cell):
 
         num_patches = _compute_num_patches(img_size, patch_size)
         self.num_branches = len(patch_size)
+        self.interpolate = Interpolate(mode="bilinear", align_corners=True)
 
         patch_embed = []
         if hybrid_backbone is None:
@@ -346,7 +348,7 @@ class VisionTransformer(nn.Cell):
             d.append(c)
         d = tuple(d)
         self.cls_token = ms.ParameterTuple(d)
-        self.pos_drop = nn.Dropout(1.0 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
 
         total_depth = sum([sum(x[-2:]) for x in depth])
         dpr = np.linspace(0, drop_path_rate, total_depth)  # stochastic depth decay rule
@@ -403,8 +405,7 @@ class VisionTransformer(nn.Cell):
         xs = []
         # print(x)
         for i in range(self.num_branches):
-            x_ = ops.interpolate(x, sizes=(self.img_size[i], self.img_size[i]), mode='bilinear') if H != self.img_size[
-                i] else x
+            x_ = self.interpolate(x, size=(self.img_size[i], self.img_size[i])) if H != self.img_size[i] else x
             tmp = self.patch_embed[i](x_)
             z = self.cls_token[i].shape
             y = Tensor(np.ones((B, z[1], z[2])), dtype=mstype.float32)

--- a/mindcv/models/densenet.py
+++ b/mindcv/models/densenet.py
@@ -11,6 +11,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -61,7 +62,7 @@ class _DenseLayer(nn.Cell):
         self.conv2 = nn.Conv2d(bn_size * growth_rate, growth_rate, kernel_size=3, stride=1, pad_mode="pad", padding=1)
 
         self.drop_rate = drop_rate
-        self.dropout = nn.Dropout(keep_prob=1 - self.drop_rate)
+        self.dropout = Dropout(p=self.drop_rate)
 
     def construct(self, features: Tensor) -> Tensor:
         bottleneck = self.conv1(self.relu1(self.norm1(features)))

--- a/mindcv/models/efficientnet.py
+++ b/mindcv/models/efficientnet.py
@@ -13,6 +13,7 @@ from mindspore.common.initializer import Normal, Uniform
 
 from .helpers import build_model_with_cfg, make_divisible
 from .layers.activation import Swish
+from .layers.compatibility import Dropout
 from .layers.drop_path import DropPath
 from .layers.pooling import GlobalAvgPooling
 from .layers.squeeze_excite import SqueezeExcite
@@ -436,7 +437,7 @@ class EfficientNet(nn.Cell):
 
         self.features = nn.SequentialCell(layers)
         self.avgpool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(1 - dropout_rate)
+        self.dropout = Dropout(p=dropout_rate)
         self.mlp_head = nn.Dense(lastconv_output_channels, num_classes)
         self._initialize_weights()
 

--- a/mindcv/models/ghostnet.py
+++ b/mindcv/models/ghostnet.py
@@ -8,6 +8,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained, make_divisible
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .layers.squeeze_excite import SqueezeExcite
 from .registry import register_model
@@ -252,7 +253,7 @@ class GhostNet(nn.Cell):
         self.act2 = nn.ReLU()
         self.flatten = nn.Flatten()
         if self.drop_rate > 0.0:
-            self.dropout = nn.Dropout(keep_prob=1 - drop_rate)
+            self.dropout = Dropout(p=drop_rate)
         self.classifier = nn.Dense(out_chs, num_classes)
         self._initialize_weights()
 

--- a/mindcv/models/googlenet.py
+++ b/mindcv/models/googlenet.py
@@ -10,6 +10,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -109,7 +110,7 @@ class InceptionAux(nn.Cell):
         self.fc2 = nn.Dense(1024, num_classes)
         self.flatten = nn.Flatten()
         self.relu = nn.ReLU()
-        self.dropout = nn.Dropout(1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
 
     def construct(self, x: Tensor) -> Tensor:
         x = self.avg_pool(x)
@@ -170,7 +171,7 @@ class GoogLeNet(nn.Cell):
             self.aux2 = InceptionAux(528, num_classes, drop_rate=drop_rate_aux)
 
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(keep_prob=1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
         self.classifier = nn.Dense(1024, num_classes)
         self._initialize_weights()
 

--- a/mindcv/models/inception_v3.py
+++ b/mindcv/models/inception_v3.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -266,7 +267,7 @@ class InceptionV3(nn.Cell):
         self.inception7c = InceptionE(2048)
 
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(keep_prob=1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
         self.num_features = 2048
         self.classifier = nn.Dense(self.num_features, num_classes)
         self._initialize_weights()

--- a/mindcv/models/inception_v4.py
+++ b/mindcv/models/inception_v4.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -278,7 +279,7 @@ class InceptionV4(nn.Cell):
         self.features = nn.SequentialCell(blocks)
 
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
         self.num_features = 1536
         self.classifier = nn.Dense(self.num_features, num_classes)
         self._initialize_weights()

--- a/mindcv/models/layers/compatibility.py
+++ b/mindcv/models/layers/compatibility.py
@@ -1,0 +1,85 @@
+import inspect
+
+import mindspore as ms
+from mindspore import nn, ops
+
+__all__ = [
+    "Dropout",
+    "Interpolate",
+    "Split",
+]
+
+
+class Dropout(nn.Dropout):
+    def __init__(self, p=0.5, dtype=ms.float32):
+        sig = inspect.signature(super().__init__)
+        if "keep_prob" in sig.parameters and "p" not in sig.parameters:
+            super().__init__(keep_prob=1.0-p, dtype=dtype)
+        elif "p" in sig.parameters:
+            super().__init__(p=p, dtype=dtype)
+        else:
+            raise NotImplementedError(
+                f"'keep_prob' or 'p' must be the parameter of `mindspore.nn.Dropout`, but got signature of it: {sig}."
+            )
+
+
+class Interpolate(nn.Cell):
+    def __init__(self, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None):
+        super().__init__()
+        sig = inspect.signature(ops.interpolate)
+        if "sizes" in sig.parameters:
+            if scale_factor is None and recompute_scale_factor is None:
+                self.kwargs = dict(
+                    roi=None,
+                    scales=None,
+                    coordinate_transformation_mode="align_corners" if align_corners is True else "half_pixel",
+                    mode=mode,
+                )
+                self.size_name = "sizes"
+            else:
+                raise NotImplementedError(
+                    "'scale_factor' and 'recompute_scale_factor' do not supported in mindspore 1.x!"
+                )
+        elif "size" in sig.parameters:
+            self.kwargs = dict(
+                scale_factor=scale_factor,
+                mode=mode,
+                align_corners=align_corners,
+                recompute_scale_factor=recompute_scale_factor,
+            )
+            self.size_name = "size"
+        else:
+            raise NotImplementedError(
+                f"'sizes' or 'size' must be the parameter of `mindspore.ops.interpolate`, "
+                f"but got signature of it: {sig}."
+            )
+
+    def construct(self, x, size=None):
+        if self.size_name == "sizes":
+            return ops.interpolate(x, sizes=size, **self.kwargs)
+        elif self.size_name == "size":
+            return ops.interpolate(x, size=size, **self.kwargs)
+        else:
+            return None
+
+
+class Split(nn.Cell):
+    """Splits the tensor into chunks.
+    In order to ensure that your code can run on different versions of mindspore,
+    you need to pass in two sets of redundant parameters.
+    """
+    def __init__(self, split_size_or_sections, output_num, axis=0):
+        super().__init__()
+        sig = inspect.signature(ops.split)
+        if "output_num" in sig.parameters:
+            self.kwargs = dict(axis=axis, output_num=output_num)
+        elif "split_size_or_sections" in sig.parameters:
+            self.kwargs = dict(split_size_or_sections=split_size_or_sections, axis=axis)
+        else:
+            raise NotImplementedError(
+                f"'output_num' or 'split_size_or_sections' must be the parameter of `mindspore.ops.split`, "
+                f"but got signature of it: {sig}."
+            )
+
+    def construct(self, x):
+        return ops.split(x, **self.kwargs)

--- a/mindcv/models/layers/drop_path.py
+++ b/mindcv/models/layers/drop_path.py
@@ -6,6 +6,8 @@ Deep Networks with Stochastic Depth (https://arxiv.org/abs/1603.09382)
 from mindspore import Tensor, nn, ops
 from mindspore.numpy import ones
 
+from .compatibility import Dropout
+
 
 class DropPath(nn.Cell):
     """DropPath (Stochastic Depth) regularization layers"""
@@ -18,7 +20,7 @@ class DropPath(nn.Cell):
         super().__init__()
         self.keep_prob = 1.0 - drop_prob
         self.scale_by_keep = scale_by_keep
-        self.dropout = nn.Dropout(self.keep_prob)
+        self.dropout = Dropout(p=drop_prob)
 
     def construct(self, x: Tensor) -> Tensor:
         if self.keep_prob == 1.0 or not self.training:

--- a/mindcv/models/layers/mlp.py
+++ b/mindcv/models/layers/mlp.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from mindspore import Tensor, nn
 
+from .compatibility import Dropout
+
 
 class Mlp(nn.Cell):
     def __init__(
@@ -20,7 +22,7 @@ class Mlp(nn.Cell):
         self.fc1 = nn.Dense(in_channels=in_features, out_channels=hidden_features, has_bias=True)
         self.act = act_layer()
         self.fc2 = nn.Dense(in_channels=hidden_features, out_channels=out_features, has_bias=True)
-        self.drop = nn.Dropout(keep_prob=1.0 - drop)
+        self.drop = Dropout(p=drop)
 
     def construct(self, x: Tensor) -> Tensor:
         x = self.fc1(x)

--- a/mindcv/models/mixnet.py
+++ b/mindcv/models/mixnet.py
@@ -10,6 +10,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .layers.squeeze_excite import SqueezeExcite
 from .registry import register_model
@@ -339,7 +340,7 @@ class MixNet(nn.Cell):
         ])
 
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(keep_prob=1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
         self.classifier = nn.Dense(feature_size, num_classes)
 
         self._initialize_weights()

--- a/mindcv/models/mlpmixer.py
+++ b/mindcv/models/mlpmixer.py
@@ -7,6 +7,7 @@ import mindspore.nn as nn
 import mindspore.ops as ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -50,9 +51,9 @@ class FeedForward(nn.Cell):
         self.net = nn.SequentialCell(
             nn.Dense(dim, hidden_dim),
             nn.GELU(),
-            nn.Dropout(keep_prob=1 - dropout),
+            Dropout(p=dropout),
             nn.Dense(hidden_dim, dim),
-            nn.Dropout(keep_prob=1 - dropout)
+            Dropout(p=dropout)
         )
 
     def construct(self, x):

--- a/mindcv/models/mnasnet.py
+++ b/mindcv/models/mnasnet.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn
 
 from .helpers import load_pretrained, make_divisible
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -137,7 +138,7 @@ class Mnasnet(nn.Cell):
         ])
         self.features = nn.SequentialCell(features)
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(keep_prob=1 - drop_rate)
+        self.dropout = Dropout(p=drop_rate)
         self.classifier = nn.Dense(1280, num_classes)
         self._initialize_weights()
 

--- a/mindcv/models/mobilenet_v2.py
+++ b/mindcv/models/mobilenet_v2.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn
 
 from .helpers import load_pretrained, make_divisible
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -219,7 +220,7 @@ class MobileNetV2(nn.Cell):
 
         self.pool = GlobalAvgPooling()
         self.classifier = nn.SequentialCell([
-            nn.Dropout(keep_prob=0.8),  # confirmed by paper authors
+            Dropout(p=0.2),  # confirmed by paper authors
             nn.Dense(last_channels, num_classes),
         ])
         self._initialize_weights()

--- a/mindcv/models/mobilenet_v3.py
+++ b/mindcv/models/mobilenet_v3.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn
 
 from .helpers import build_model_with_cfg, make_divisible
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .layers.squeeze_excite import SqueezeExcite
 from .registry import register_model
@@ -202,7 +203,7 @@ class MobileNetV3(nn.Cell):
         self.classifier = nn.SequentialCell([
             nn.Dense(output_channels, last_channels),
             nn.HSwish(),
-            nn.Dropout(keep_prob=0.8),
+            Dropout(p=0.2),
             nn.Dense(last_channels, num_classes),
         ])
         self._initialize_weights()

--- a/mindcv/models/nasnet.py
+++ b/mindcv/models/nasnet.py
@@ -8,6 +8,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -807,7 +808,7 @@ class NASNetAMobile(nn.Cell):
         )  # 24, 4
 
         self.relu = nn.ReLU()
-        self.dropout = nn.Dropout(keep_prob=0.5)
+        self.dropout = Dropout(p=0.5)
         self.classifier = nn.Dense(in_channels=24 * filters, out_channels=num_classes)
         self.pool = GlobalAvgPooling()
         self._initialize_weights()

--- a/mindcv/models/pit.py
+++ b/mindcv/models/pit.py
@@ -15,6 +15,7 @@ from mindspore import nn, ops
 
 from .helpers import load_pretrained
 from .layers import DropPath, Identity
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -125,9 +126,9 @@ class Attention(nn.Cell):
         self.q = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
         self.k = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
         self.v = nn.Dense(in_channels=dim, out_channels=dim, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(keep_prob=1 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(keep_prob=1 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.softmax = nn.Softmax(axis=-1)
 
         self.batchmatmul = ops.BatchMatMul()
@@ -198,7 +199,7 @@ class Mlp(nn.Cell):
         self.fc1 = nn.Dense(in_channels=in_features, out_channels=hidden_features, has_bias=True)
         self.act = act_layer()
         self.fc2 = nn.Dense(in_channels=hidden_features, out_channels=out_features, has_bias=True)
-        self.drop = nn.Dropout(keep_prob=1.0 - drop)
+        self.drop = Dropout(p=drop)
 
     def construct(self, x):
         x = self.fc1(x)
@@ -312,7 +313,7 @@ class PoolingTransformer(nn.Cell):
         self.patch_embed = conv_embedding(in_chans, base_dims[0] * heads[0], patch_size, stride, padding)
         self.cls_token = Parameter(Tensor(np.random.randn(1, 1, base_dims[0] * heads[0]), mstype.float32))
 
-        self.pos_drop = nn.Dropout(keep_prob=1.0 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
         self.tile = ops.Tile()
 
         self.transformers = nn.CellList([])

--- a/mindcv/models/pnasnet.py
+++ b/mindcv/models/pnasnet.py
@@ -11,6 +11,7 @@ from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
 from .layers import GlobalAvgPooling
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -424,7 +425,7 @@ class Pnasnet(nn.Cell):
 
         self.relu = nn.ReLU()
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout(keep_prob=0.5)
+        self.dropout = Dropout(p=0.5)
         self.last_linear = nn.Dense(in_channels=1080, out_channels=num_classes)
 
         self._initialize_weights()

--- a/mindcv/models/poolformer.py
+++ b/mindcv/models/poolformer.py
@@ -14,6 +14,7 @@ from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
 from .layers import DropPath, Identity
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -80,7 +81,7 @@ class ConvMlp(nn.Cell):
         self.fc1 = nn.Conv2d(in_features, hidden_features, kernel_size=1, has_bias=bias[0])
         self.norm = norm_layer(hidden_features) if norm_layer else Identity()
         self.act = act_layer(approximate=False)
-        self.drop = nn.Dropout(1 - drop)
+        self.drop = Dropout(p=drop)
         self.fc2 = nn.Conv2d(hidden_features, out_features, kernel_size=1, has_bias=bias[1])
         self.cls_init_weights()
 

--- a/mindcv/models/pvt.py
+++ b/mindcv/models/pvt.py
@@ -13,6 +13,7 @@ from mindspore import Tensor
 from mindspore.common import initializer as weight_init
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.drop_path import DropPath
 from .layers.identity import Identity
 from .layers.mlp import Mlp
@@ -68,9 +69,9 @@ class Attention(nn.Cell):
 
         self.q = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.kv = nn.Dense(dim, dim * 2, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(1 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.qk_batmatmul = ops.BatchMatMul(transpose_b=True)
         self.batmatmul = ops.BatchMatMul()
         self.softmax = nn.Softmax(axis=-1)
@@ -203,7 +204,7 @@ class PyramidVisionTransformer(nn.Cell):
         cur = 0
         b_list = []
         self.pos_embed = []
-        self.pos_drop = nn.Dropout(1 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
         for i in range(num_stages):
             block = nn.CellList(
                 [Block(dim=embed_dims[i], num_heads=num_heads[i], mlp_ratio=mlp_ratios[i], qkv_bias=qkv_bias,
@@ -221,7 +222,7 @@ class PyramidVisionTransformer(nn.Cell):
                                        embed_dim=embed_dims[0])
         num_patches = self.patch_embed1.num_patches
         self.pos_embed1 = mindspore.Parameter(ops.zeros((1, num_patches, embed_dims[0]), mindspore.float16))
-        self.pos_drop1 = nn.Dropout(1 - drop_rate)
+        self.pos_drop1 = Dropout(p=drop_rate)
 
         self.patch_embed2 = PatchEmbed(img_size=img_size // (2 ** (1 + 1)),
                                        patch_size=2,
@@ -229,7 +230,7 @@ class PyramidVisionTransformer(nn.Cell):
                                        embed_dim=embed_dims[1])
         num_patches = self.patch_embed2.num_patches
         self.pos_embed2 = mindspore.Parameter(ops.zeros((1, num_patches, embed_dims[1]), mindspore.float16))
-        self.pos_drop2 = nn.Dropout(1 - drop_rate)
+        self.pos_drop2 = Dropout(p=drop_rate)
 
         self.patch_embed3 = PatchEmbed(img_size=img_size // (2 ** (2 + 1)),
                                        patch_size=2,
@@ -237,7 +238,7 @@ class PyramidVisionTransformer(nn.Cell):
                                        embed_dim=embed_dims[2])
         num_patches = self.patch_embed3.num_patches
         self.pos_embed3 = mindspore.Parameter(ops.zeros((1, num_patches, embed_dims[2]), mindspore.float16))
-        self.pos_drop3 = nn.Dropout(1 - drop_rate)
+        self.pos_drop3 = Dropout(p=drop_rate)
 
         self.patch_embed4 = PatchEmbed(img_size // (2 ** (3 + 1)),
                                        patch_size=2,
@@ -245,7 +246,7 @@ class PyramidVisionTransformer(nn.Cell):
                                        embed_dim=embed_dims[3])
         num_patches = self.patch_embed4.num_patches + 1
         self.pos_embed4 = mindspore.Parameter(ops.zeros((1, num_patches, embed_dims[3]), mindspore.float16))
-        self.pos_drop4 = nn.Dropout(1 - drop_rate)
+        self.pos_drop4 = Dropout(p=drop_rate)
         self.Blocks = nn.CellList(b_list)
 
         self.norm = norm_layer([embed_dims[3]])
@@ -290,10 +291,9 @@ class PyramidVisionTransformer(nn.Cell):
         if H * W == self.patch_embed1.num_patches:
             return pos_embed
         else:
-            ResizeBilinear = nn.ResizeBilinear()
-
             pos_embed = self.transpose(self.reshape(pos_embed, (1, ph, pw, -1)), (0, 3, 1, 2))
-            pos_embed = ResizeBilinear(pos_embed, (H, W))
+            resize_bilinear = ops.ResizeBilinear((H, W))
+            pos_embed = resize_bilinear(pos_embed)
 
             pos_embed = self.transpose(self.reshape(pos_embed, (1, -1, H * W)), (0, 2, 1))
 

--- a/mindcv/models/pvtv2.py
+++ b/mindcv/models/pvtv2.py
@@ -13,6 +13,7 @@ from mindspore.common import initializer as weight_init
 
 from .helpers import load_pretrained
 from .layers import DropPath, Identity
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -73,7 +74,7 @@ class Mlp(nn.Cell):
         self.dwconv = DWConv(hidden_features)
         self.act = act_layer()
         self.fc2 = nn.Dense(hidden_features, out_features)
-        self.drop = nn.Dropout(1 - drop)
+        self.drop = Dropout(p=drop)
         self.linear = linear
         if self.linear:
             self.relu = nn.ReLU()
@@ -105,9 +106,9 @@ class Attention(nn.Cell):
 
         self.q = nn.Dense(dim, dim, has_bias=qkv_bias)
         self.kv = nn.Dense(dim, dim * 2, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(dim, dim)
-        self.proj_drop = nn.Dropout(1 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.qk_batmatmul = ops.BatchMatMul(transpose_b=True)
         self.batmatmul = ops.BatchMatMul()
         self.softmax = nn.Softmax(axis=-1)

--- a/mindcv/models/res2net.py
+++ b/mindcv/models/res2net.py
@@ -10,6 +10,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Split
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -93,6 +94,7 @@ class Bottle2neck(nn.Cell):
         self.stype = stype
         self.scale = scale
         self.width = width
+        self.split = Split(split_size_or_sections=self.width, output_num=self.scale, axis=1)
 
     def construct(self, x: Tensor) -> Tensor:
         identity = x
@@ -101,7 +103,7 @@ class Bottle2neck(nn.Cell):
         out = self.bn1(out)
         out = self.relu(out)
 
-        spx = ops.split(out, axis=1, output_num=self.scale)
+        spx = self.split(out)
 
         sp = self.convs[0](spx[0])
         sp = self.bns[0](sp)

--- a/mindcv/models/resnest.py
+++ b/mindcv/models/resnest.py
@@ -9,6 +9,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import build_model_with_cfg, make_divisible
+from .layers.compatibility import Dropout
 from .layers.identity import Identity
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
@@ -319,7 +320,7 @@ class ResNeSt(nn.Cell):
             self.feature_info.append(dict(chs=block.expansion * 512, reduction=32, name='layer4'))
 
         self.avgpool = GlobalAvgPooling()
-        self.drop = nn.Dropout(keep_prob=1.0 - drop_rate) if drop_rate > 0.0 else None
+        self.drop = Dropout(p=drop_rate) if drop_rate > 0.0 else None
         self.fc = nn.Dense(512 * block.expansion, num_classes)
 
         self._initialize_weights()

--- a/mindcv/models/rexnet.py
+++ b/mindcv/models/rexnet.py
@@ -11,6 +11,7 @@ import mindspore.nn as nn
 
 from .helpers import build_model_with_cfg, make_divisible
 from .layers import Conv2dNormActivation, DropPath, GlobalAvgPooling, SqueezeExcite
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -212,11 +213,11 @@ class ReXNetV1(nn.Cell):
         self.features = nn.SequentialCell(*features)
         if self.useconv:
             self.cls = nn.SequentialCell(
-                nn.Dropout(1.0 - drop_rate),
+                Dropout(p=drop_rate),
                 nn.Conv2d(pen_channels, num_classes, 1, has_bias=True))
         else:
             self.cls = nn.SequentialCell(
-                nn.Dropout(1.0 - drop_rate),
+                Dropout(p=drop_rate),
                 nn.Dense(pen_channels, num_classes))
         self._initialize_weights()
 

--- a/mindcv/models/senet.py
+++ b/mindcv/models/senet.py
@@ -10,6 +10,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .layers.squeeze_excite import SqueezeExciteV2
 from .registry import register_model
@@ -310,7 +311,7 @@ class SENet(nn.Cell):
 
         self.pool = GlobalAvgPooling()
         if self.drop_rate > 0.:
-            self.dropout = nn.Dropout(keep_prob=1. - self.drop_rate)
+            self.dropout = Dropout(p=self.drop_rate)
         self.classifier = nn.Dense(self.num_features, self.num_classes)
 
         self._initialize_weights()

--- a/mindcv/models/squeezenet.py
+++ b/mindcv/models/squeezenet.py
@@ -7,6 +7,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .layers.pooling import GlobalAvgPooling
 from .registry import register_model
 
@@ -117,7 +118,7 @@ class SqueezeNet(nn.Cell):
 
         self.final_conv = nn.Conv2d(512, num_classes, kernel_size=1, has_bias=True)
         self.classifier = nn.SequentialCell([
-            nn.Dropout(keep_prob=1 - drop_rate),
+            Dropout(p=drop_rate),
             self.final_conv,
             nn.ReLU(),
             GlobalAvgPooling()

--- a/mindcv/models/vgg.py
+++ b/mindcv/models/vgg.py
@@ -10,6 +10,7 @@ import mindspore.common.initializer as init
 from mindspore import Tensor, nn
 
 from .helpers import load_pretrained
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -95,10 +96,10 @@ class VGG(nn.Cell):
         self.classifier = nn.SequentialCell([
             nn.Dense(512 * 7 * 7, 4096),
             nn.ReLU(),
-            nn.Dropout(keep_prob=1 - drop_rate),
+            Dropout(p=drop_rate),
             nn.Dense(4096, 4096),
             nn.ReLU(),
-            nn.Dropout(keep_prob=1 - drop_rate),
+            Dropout(p=drop_rate),
             nn.Dense(4096, num_classes),
         ])
         self._initialize_weights()

--- a/mindcv/models/visformer.py
+++ b/mindcv/models/visformer.py
@@ -13,6 +13,7 @@ from mindspore.common.initializer import Constant, HeNormal, TruncatedNormal, in
 
 from .helpers import _ntuple, load_pretrained
 from .layers import DropPath, GlobalAvgPooling, Identity
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -73,7 +74,7 @@ class Mlp(nn.Cell):
                 hidden_features = in_features * 2
         self.hidden_features = hidden_features
         self.group = group
-        self.drop = nn.Dropout(1 - drop)
+        self.drop = Dropout(p=drop)
         self.conv1 = nn.Conv2d(in_features, hidden_features, 1, 1, pad_mode="pad", padding=0)
         self.act1 = act_layer()
         if self.spatial_conv:
@@ -118,9 +119,9 @@ class Attention(nn.Cell):
         self.scale = head_dim**qk_scale_factor
 
         self.qkv = nn.Conv2d(dim, head_dim * num_heads * 3, 1, 1, pad_mode="pad", padding=0, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(1 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Conv2d(self.head_dim * self.num_heads, dim, 1, 1, pad_mode="pad", padding=0)
-        self.proj_drop = nn.Dropout(1 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
 
     def construct(self, x: Tensor) -> Tensor:
         B, C, H, W = x.shape
@@ -275,7 +276,7 @@ class Visformer(nn.Cell):
         ])
         img_size //= 2
 
-        self.pos_drop = nn.Dropout(1 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
         # stage0
         if depth[0]:
             self.patch_embed0 = PatchEmbed(img_size=img_size, patch_size=2, in_chans=self.init_channels,

--- a/mindcv/models/vit.py
+++ b/mindcv/models/vit.py
@@ -11,6 +11,7 @@ from mindspore.common.initializer import Normal, initializer
 from mindspore.common.parameter import Parameter
 
 from .helpers import ConfigDict, load_pretrained
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -127,9 +128,9 @@ class Attention(nn.Cell):
         self.scale = Tensor(head_dim**-0.5)
 
         self.qkv = nn.Dense(dim, dim * 3)
-        self.attn_drop = nn.Dropout(attention_keep_prob)
+        self.attn_drop = Dropout(p=1.0-attention_keep_prob)
         self.out = nn.Dense(dim, dim)
-        self.out_drop = nn.Dropout(keep_prob)
+        self.out_drop = Dropout(p=1.0-keep_prob)
 
         self.mul = ops.Mul()
         self.reshape = ops.Reshape()
@@ -194,7 +195,7 @@ class FeedForward(nn.Cell):
         self.dense1 = nn.Dense(in_features, hidden_features)
         self.activation = activation()
         self.dense2 = nn.Dense(hidden_features, out_features)
-        self.dropout = nn.Dropout(keep_prob)
+        self.dropout = Dropout(p=1.0-keep_prob)
 
     def construct(self, x):
         """Feed Forward construct."""
@@ -364,7 +365,7 @@ class DenseHead(nn.Cell):
     ) -> None:
         super().__init__()
 
-        self.dropout = nn.Dropout(keep_prob)
+        self.dropout = Dropout(p=1.0-keep_prob)
         self.classifier = nn.Dense(input_channel, num_classes, has_bias=has_bias, activation=activation)
 
     def construct(self, x):
@@ -568,7 +569,7 @@ class ViT(nn.Cell):
             self.mean = ops.ReduceMean(keep_dims=False)
 
         self.pool = pool
-        self.pos_dropout = nn.Dropout(keep_prob)
+        self.pos_dropout = Dropout(p=1.0-keep_prob)
         self.norm = norm((embed_dim,))
         self.tile = ops.Tile()
         self.transformer = TransformerEncoder(

--- a/mindcv/models/xception.py
+++ b/mindcv/models/xception.py
@@ -8,6 +8,7 @@ from mindspore import Tensor, nn, ops
 
 from .helpers import load_pretrained
 from .layers import GlobalAvgPooling
+from .layers.compatibility import Dropout
 from .registry import register_model
 
 __all__ = [
@@ -156,7 +157,7 @@ class Xception(nn.Cell):
         self.bn4 = nn.BatchNorm2d(2048)
 
         self.pool = GlobalAvgPooling()
-        self.dropout = nn.Dropout()
+        self.dropout = Dropout(p=0.5)
         self.classifier = nn.Dense(2048, num_classes)
 
         self._initialize_weights()

--- a/mindcv/models/xcit.py
+++ b/mindcv/models/xcit.py
@@ -13,7 +13,8 @@ from mindspore import dtype as mstype
 from mindspore import nn, numpy, ops
 
 from .helpers import _ntuple, load_pretrained
-from .layers import DropPath
+from .layers.compatibility import Dropout
+from .layers.drop_path import DropPath
 from .layers.mlp import Mlp
 from .registry import register_model
 
@@ -193,9 +194,9 @@ class ClassAttention(nn.Cell):
 
         self.qkv = nn.Dense(
             in_channels=dim, out_channels=dim * 3, has_bias=qkv_bias)
-        self.attn_drop = nn.Dropout(keep_prob=1 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.proj = nn.Dense(in_channels=dim, out_channels=dim)
-        self.proj_drop = nn.Dropout(keep_prob=1 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
         self.softmax = nn.Softmax(axis=-1)
 
         self.attn_matmul_v = ops.BatchMatMul()
@@ -286,10 +287,10 @@ class XCA(nn.Cell):
             in_channels=dim, out_channels=dim * 3, has_bias=qkv_bias)
         self.q_matmul_k = ops.BatchMatMul(transpose_b=True)
         self.softmax = nn.Softmax(axis=-1)
-        self.attn_drop = nn.Dropout(keep_prob=1.0 - attn_drop)
+        self.attn_drop = Dropout(p=attn_drop)
         self.attn_matmul_v = ops.BatchMatMul()
         self.proj = nn.Dense(in_channels=dim, out_channels=dim)
-        self.proj_drop = nn.Dropout(keep_prob=1.0 - proj_drop)
+        self.proj_drop = Dropout(p=proj_drop)
 
     def construct(self, x):
         B, N, C = x.shape
@@ -407,7 +408,7 @@ class XCiT(nn.Cell):
 
         self.cls_token = Parameter(
             ops.zeros((1, 1, embed_dim), mstype.float32))
-        self.pos_drop = nn.Dropout(keep_prob=1.0 - drop_rate)
+        self.pos_drop = Dropout(p=drop_rate)
 
         dpr = [drop_path_rate for i in range(depth)]
         self.blocks = nn.CellList([

--- a/mindcv/optim/adan.py
+++ b/mindcv/optim/adan.py
@@ -2,7 +2,6 @@
 import mindspore as ms
 from mindspore import ops
 from mindspore.common import dtype as mstype
-from mindspore.common.api import ms_function
 from mindspore.common.tensor import Tensor
 from mindspore.nn.optim.optimizer import Optimizer, opt_init_args_register
 
@@ -145,7 +144,6 @@ class Adan(Optimizer):
 
         self.weight_decay = Tensor(weight_decay, mstype.float32)
 
-    @ms_function
     def construct(self, gradients):
         params = self._parameters
         moment1 = self.moment1

--- a/mindcv/optim/nadam.py
+++ b/mindcv/optim/nadam.py
@@ -3,7 +3,6 @@ import numpy as np
 
 import mindspore as ms
 from mindspore import ops
-from mindspore.common.api import ms_function
 from mindspore.common.initializer import initializer
 from mindspore.common.parameter import Parameter
 from mindspore.common.tensor import Tensor
@@ -49,7 +48,6 @@ class NAdam(Optimizer):
         self.mu_schedule = Parameter(initializer(1, [1], ms.float32), name="mu_schedule")
         self.beta2_power = Parameter(initializer(1, [1], ms.float32), name="beta2_power")
 
-    @ms_function
     def construct(self, gradients):
         lr = self.get_lr()
         params = self.parameters

--- a/mindcv/utils/amp.py
+++ b/mindcv/utils/amp.py
@@ -1,10 +1,13 @@
 """ auto mixed precision related functions """
 
 # from mindspore.amp import LossScaler  # this line of code leads to “get rank id error” in modelarts
-from mindspore.common.api import ms_class
+try:
+    from mindspore import jit_class
+except ImportError:
+    from mindspore import ms_class as jit_class
 
 
-@ms_class
+@jit_class
 class LossScaler:
     r"""
     Loss scaler abstract class when using mixed precision.

--- a/mindcv/utils/callbacks.py
+++ b/mindcv/utils/callbacks.py
@@ -269,9 +269,16 @@ class StateMonitor(Callback):
 
     def _get_lr_from_cbp(self, cb_params):
         optimizer = self._get_optimizer_from_cbp(cb_params)
-        step = optimizer.global_step
+        if optimizer.global_step < 1:
+            _logger.warning(
+                "`global_step` of optimizer is less than 1. It seems to be a overflow at the first step. "
+                "If you keep seeing this message, it means that the optimizer never actually called."
+            )
+            optim_step = Tensor((0,), ms.int32)
+        else:  # if the optimizer is successfully called, the global_step will actually be the value of next step.
+            optim_step = optimizer.global_step - 1
         if optimizer.dynamic_lr:
-            lr = optimizer.learning_rate(step - 1)[0]
+            lr = optimizer.learning_rate(optim_step)[0]
         else:
             lr = optimizer.learning_rate
         return lr

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ pytest tests/modules/*.py
 
 - `tasks` for system test (ST): test the training and validation pipeline.
 
-To test the training process (in graph mode and pynative+ms_function mode) and the validation process, run
+To test the training process (in graph mode and pynative+mindspore.jit mode) and the validation process, run
 ```shell
 pytest tests/tasks/test_train_val_imagenet_subset.py
 ```

--- a/tests/tasks/non_cpu/test_train_val_imagenet_subset.py
+++ b/tests/tasks/non_cpu/test_train_val_imagenet_subset.py
@@ -1,6 +1,6 @@
 """
 Test train and validate pipelines.
-For training, both graph mode and pynative mode with ms_function will be tested.
+For training, both graph mode and pynative mode with mindspore.jit will be tested.
 """
 import os
 import subprocess

--- a/tests/tasks/test_train_val_imagenet_subset.py
+++ b/tests/tasks/test_train_val_imagenet_subset.py
@@ -1,6 +1,6 @@
 """
 Test train and validate pipelines.
-For training, both graph mode and pynative mode with ms_function will be tested.
+For training, both graph mode and pynative mode with mindspore.jit will be tested.
 """
 import os
 import subprocess

--- a/train_with_func.py
+++ b/train_with_func.py
@@ -21,6 +21,11 @@ from mindcv.utils.random import set_seed
 
 from config import parse_args  # isort: skip
 
+try:
+    from mindspore import jit
+except ImportError:
+    from mindspore import ms_function as jit
+
 logger = logging.getLogger("train")
 logger.setLevel(logging.INFO)
 h1 = logging.StreamHandler()
@@ -366,7 +371,7 @@ def train_epoch(
         grad_reducer = ops.functional.identity
 
     # Define function of one-step training
-    @ms.ms_function
+    @jit
     def train_step(data, label):
         (loss, logits), grads = grad_fn(data, label)
         grads = grad_reducer(grads)


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

MindSpore 2.0 is going to release in next few months. A large number of APIs have incompatible upgrades.

This commit upgrades the dependent mindspore to version 2.0, and maintains compatibility with version 1.8 through wrapping the interface. And we will keep the compatibility with version 1.8 for a while.

The most important changes are listed as follows:
- nn.Dropout
- ops.interpolate
- ops.split
- nn.OneHot
- nn.ResizeBilinear
- ms_function -> jit
- ms_class -> jit_class

## Test Plan

Model Inference and Training is ok.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
