### PR TITLE
fix: fix bug in function load_pretrained

### DIFF
--- a/mindcv/models/helpers.py
+++ b/mindcv/models/helpers.py
@@ -57,14 +57,14 @@ def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_
         classifier_bias.set_data(classifier_bias[:1000], slice_shape=True)
     elif num_classes != default_cfg["num_classes"]:
         params_names = list(param_dict.keys())
-        param_dict.pop(
-            _search_param_name(params_names, classifier_name + ".weight"),
-            "No Parameter {} in ParamDict".format(classifier_name + ".weight"),
-        )
-        param_dict.pop(
-            _search_param_name(params_names, classifier_name + ".bias"),
-            "No Parameter {} in ParamDict".format(classifier_name + ".bias"),
-        )
+        for param_name in _search_param_name(params_names, classifier_name + ".weight"):
+            param_dict.pop(param_name,
+                           "Parameter {} has been deleted from ParamDict.".format(param_name),
+                           )
+        for param_name in _search_param_name(params_names, classifier_name + ".bias"):
+            param_dict.pop(param_name,
+                           "Parameter {} has been deleted from ParamDict.".format(param_name),
+                           )
 
     if filter_fn is not None:
         param_dict = filter_fn(param_dict)
@@ -73,9 +73,9 @@ def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_
 
 
 def make_divisible(
-    v: float,
-    divisor: int,
-    min_value: Optional[int] = None,
+        v: float,
+        divisor: int,
+        min_value: Optional[int] = None,
 ) -> int:
     """Find the smallest integer larger than v and divisible by divisor."""
     if not min_value:
@@ -97,10 +97,11 @@ def _ntuple(n):
 
 
 def _search_param_name(params_names: List, param_name: str) -> str:
+    search_results = []
     for pi in params_names:
         if param_name in pi:
-            return pi
-    return ""
+            search_results.append(pi)
+    return search_results
 
 
 def auto_map(model, param_dict):

--- a/mindcv/models/helpers.py
+++ b/mindcv/models/helpers.py
@@ -58,13 +58,15 @@ def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_
     elif num_classes != default_cfg["num_classes"]:
         params_names = list(param_dict.keys())
         for param_name in _search_param_name(params_names, classifier_name + ".weight"):
-            param_dict.pop(param_name,
-                           "Parameter {} has been deleted from ParamDict.".format(param_name),
-                           )
+            param_dict.pop(
+                param_name,
+                "Parameter {} has been deleted from ParamDict.".format(param_name),
+            )
         for param_name in _search_param_name(params_names, classifier_name + ".bias"):
-            param_dict.pop(param_name,
-                           "Parameter {} has been deleted from ParamDict.".format(param_name),
-                           )
+            param_dict.pop(
+                param_name,
+                "Parameter {} has been deleted from ParamDict.".format(param_name),
+            )
 
     if filter_fn is not None:
         param_dict = filter_fn(param_dict)
@@ -73,9 +75,9 @@ def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_
 
 
 def make_divisible(
-        v: float,
-        divisor: int,
-        min_value: Optional[int] = None,
+    v: float,
+    divisor: int,
+    min_value: Optional[int] = None,
 ) -> int:
     """Find the smallest integer larger than v and divisible by divisor."""
     if not min_value:
@@ -96,7 +98,7 @@ def _ntuple(n):
     return parse
 
 
-def _search_param_name(params_names: List, param_name: str) -> str:
+def _search_param_name(params_names: List, param_name: str) -> list:
     search_results = []
     for pi in params_names:
         if param_name in pi:
@@ -113,20 +115,20 @@ def auto_map(model, param_dict):
 
     for param in net_param:
         if param.name not in ckpt_param:
-            print('Cannot find a param to load: ', param.name)
+            print("Cannot find a param to load: ", param.name)
             poss = difflib.get_close_matches(param.name, ckpt_param, n=3, cutoff=0.6)
             if len(poss) > 0:
-                print('=> Find most matched param: ', poss[0], ', loaded')
+                print("=> Find most matched param: ", poss[0], ", loaded")
                 updated_param_dict[param.name] = updated_param_dict.pop(poss[0])  # replace
                 remap[param.name] = poss[0]
             else:
-                raise ValueError('Cannot find any matching param from: ', ckpt_param)
+                raise ValueError("Cannot find any matching param from: ", ckpt_param)
 
     if remap != {}:
-        print('WARNING: Auto mapping succeed. Please check the found mapping names to ensure correctness')
-        print('\tNet Param\t<---\tCkpt Param')
+        print("WARNING: Auto mapping succeed. Please check the found mapping names to ensure correctness")
+        print("\tNet Param\t<---\tCkpt Param")
         for k in remap:
-            print(f'\t{k}\t<---\t{remap[k]}')
+            print(f"\t{k}\t<---\t{remap[k]}")
 
     return updated_param_dict
 
@@ -166,12 +168,12 @@ def load_model_checkpoint(model: nn.Cell, checkpoint_path: str = "", ema: bool =
 
 
 def build_model_with_cfg(
-        model_cls: Callable,
-        pretrained: bool,
-        default_cfg: Dict,
-        features_only: bool = False,
-        out_indices: List[int] = [0, 1, 2, 3, 4],
-        **kwargs,
+    model_cls: Callable,
+    pretrained: bool,
+    default_cfg: Dict,
+    features_only: bool = False,
+    out_indices: List[int] = [0, 1, 2, 3, 4],
+    **kwargs,
 ):
     """Build model with specific model configurations
 


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

The function `load_pretrained` can only delete the parameter `classifier.weight`, but the parameter `opt.classifier.weight` which should be delete together was still kept. This PR fix this bug and delete all parameters in dense layer when load pretrained weights.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
