### PR TITLE
hoxfix: mindspore is not compatible with the latest version of pillow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/dev.txt
+        pip install "Pillow==9.1.1"
         # MindSpore must be installed following the instruction from official web, but not from pypi.
         # That's why we exclude mindspore from requirements.txt. Does this work?
         pip install "mindspore>=1.8,<=1.10"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements/docs.txt
+          pip install "Pillow==9.1.1"
+          pip install "mindspore>=1.8,<=1.10"
       - name: Build site
         run: mkdocs build
       - name: Deploy to gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/dev.txt
+        pip install "Pillow==9.1.1"
         pip install "mindspore>=1.8,<=1.10"
         pip install build twine
     - name: Build package

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,4 @@
 -r ../requirements.txt
-mindspore>=1.8,<=1.10
 mkdocs>=1.4.2
 mkdocs-material>=9.1.7
 mkdocstrings[python]>=0.21.2


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

`mindspore` is not compatible with the latest version(10.0.0, relaese on Jul 1, 2023) of `pillow`, which will cause CI [failure](https://github.com/mindspore-lab/mindcv/actions/runs/5452081207/jobs/9919099152).
We force to install version 9.1.1 of pillow.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
