### PR TITLE
docs: add explanation of suffix 'hardware' of training recipe in config README

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -17,6 +17,13 @@ This folder contains training recipes and model readme files for each model. The
         ├── README.md //this file
 ```
 
+> Note: Our training recipes are verified on specific hardware, and the suffix `hardware` (ascend or gpu) in the
+> file name of training recipes indicates different hardware. Since Mindspore operators have different precision and
+> performance on different hardware, different training recipes are required under different hardware. However, if you
+> want to train on another hardware (e.g. GPU) using the training recipe under specific hardware (e.g. Ascend), you only
+> need to make minor or no adjustments to the hyperparameters, because the training recipe has a certain degree of
+> generalization across different hardware.
+
 ### Model Readme Writing Guideline
 The model readme file in each sub-folder provides the introduction, reproduced results, and running guideline for each model.
 


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
