### PR TITLE
refactor(optimizer): change "filter_bias_and_bn" to "weight_decay_filter"

### DIFF
--- a/config.py
+++ b/config.py
@@ -182,8 +182,14 @@ def create_parser():
                        help='Weight decay (default=1e-6)')
     group.add_argument('--use_nesterov', type=str2bool, nargs='?', const=True, default=False,
                        help='Enables the Nesterov momentum (default=False)')
-    group.add_argument('--filter_bias_and_bn', type=str2bool, nargs='?', const=True, default=True,
-                       help='Filter Bias and BatchNorm (default=True)')
+    group.add_argument('--weight_decay_filter', type=str, default="disable",
+                       choices=['disable', 'auto', 'norm_and_bias'],
+                       help='filter parameters from weight_decay. '
+                            'choice: "disable" - No parameters to filter from weight_decay; "auto" - In this case, '
+                            'we do not apply weight decay filtering to any parameters. However, MindSpore currently '
+                            'automatically filters norm parameters from weight decay. It is unclear whether there '
+                            'will be any changes in future versions of MindSpore, so it is recommended to stay updated;'
+                            '"norm_and_bias" - Filter the paramtersof Norm layer and Bias from weight decay')
     group.add_argument('--eps', type=float, default=1e-10,
                        help='Term Added to the Denominator to Improve Numerical Stability (default=1e-10)')
 

--- a/config.py
+++ b/config.py
@@ -167,6 +167,8 @@ def create_parser():
                        help='Whether use clip grad (default=False)')
     group.add_argument('--clip_value', type=float, default=15.0,
                        help='Clip value (default=15.0)')
+    group.add_argument('--layer_decay', type=float, default=None,
+                       help='layer-wise learning rate decay (default: None)')
     group.add_argument('--gradient_accumulation_steps', type=int, default=1,
                        help="Accumulate the gradients of n batches before update.")
 

--- a/configs/bit/bit_resnet101_ascend.yaml
+++ b/configs/bit/bit_resnet101_ascend.yaml
@@ -41,7 +41,7 @@ multi_step_decay_milestones: [30, 40, 50, 60, 70, 80, 85]
 
 # optimizer
 opt: 'sgd'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/bit/bit_resnet50_ascend.yaml
+++ b/configs/bit/bit_resnet50_ascend.yaml
@@ -40,7 +40,7 @@ multi_step_decay_milestones: [30, 40, 50, 60, 70, 80, 85]
 
 # optimizer
 opt: 'sgd'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/bit/bit_resnet50x3_ascend.yaml
+++ b/configs/bit/bit_resnet50x3_ascend.yaml
@@ -43,7 +43,7 @@ multi_step_decay_milestones: [30, 40, 50, 60, 70, 80, 85]
 
 # optimizer
 opt: 'sgd'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/cmt/cmt_small_ascend.yaml
+++ b/configs/cmt/cmt_small_ascend.yaml
@@ -52,7 +52,6 @@ warmup_epochs: 5
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: 'dynamic'

--- a/configs/coat/coat_lite_mini_ascend.yaml
+++ b/configs/coat/coat_lite_mini_ascend.yaml
@@ -54,6 +54,5 @@ cycle_decay: 1.0
 # optimizer
 opt: 'adamw'
 weight_decay: 0.025
-filter_bias_and_bn: True
 loss_scale: 1024
 use_nesterov: False

--- a/configs/coat/coat_lite_tiny_ascend.yaml
+++ b/configs/coat/coat_lite_tiny_ascend.yaml
@@ -54,6 +54,5 @@ cycle_decay: 1.0
 # optimizer
 opt: 'adamw'
 weight_decay: 0.025
-filter_bias_and_bn: True
 loss_scale: 1024
 use_nesterov: False

--- a/configs/coat/coat_mini_ascend.yaml
+++ b/configs/coat/coat_mini_ascend.yaml
@@ -55,7 +55,6 @@ epoch_size: 300
 # optimizer
 opt: 'lion'
 weight_decay: 0.15
-filter_bias_and_bn: True
 loss_scale: 4096
 use_nesterov: False
 loss_scale_type: dynamic

--- a/configs/coat/coat_tiny_ascend.yaml
+++ b/configs/coat/coat_tiny_ascend.yaml
@@ -57,7 +57,6 @@ epoch_size: 300
 # optimizer
 opt: 'lion'
 weight_decay: 0.15
-filter_bias_and_bn: True
 loss_scale: 4096
 use_nesterov: False
 loss_scale_type: dynamic

--- a/configs/convit/convit_base_ascend.yaml
+++ b/configs/convit/convit_base_ascend.yaml
@@ -51,5 +51,4 @@ decay_epochs: 260
 opt: 'adamw'
 weight_decay: 0.1
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_base_plus_ascend.yaml
+++ b/configs/convit/convit_base_plus_ascend.yaml
@@ -51,5 +51,4 @@ decay_epochs: 260
 opt: 'adamw'
 weight_decay: 0.1
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_small_ascend.yaml
+++ b/configs/convit/convit_small_ascend.yaml
@@ -51,5 +51,4 @@ decay_epochs: 260
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_small_plus_ascend.yaml
+++ b/configs/convit/convit_small_plus_ascend.yaml
@@ -51,5 +51,4 @@ decay_epochs: 260
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_tiny_ascend.yaml
+++ b/configs/convit/convit_tiny_ascend.yaml
@@ -50,5 +50,4 @@ decay_epochs: 295
 opt: 'adamw'
 weight_decay: 0.0001
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_tiny_gpu.yaml
+++ b/configs/convit/convit_tiny_gpu.yaml
@@ -47,5 +47,4 @@ decay_epochs: 200
 # optimizer
 opt: 'adamw'
 weight_decay: 0.025
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convit/convit_tiny_plus_ascend.yaml
+++ b/configs/convit/convit_tiny_plus_ascend.yaml
@@ -50,5 +50,4 @@ decay_epochs: 260
 opt: 'adamw'
 weight_decay: 0.0001
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/convnext/convnext_base_ascend.yaml
+++ b/configs/convnext/convnext_base_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: 'auto'

--- a/configs/convnext/convnext_small_ascend.yaml
+++ b/configs/convnext/convnext_small_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: 'auto'

--- a/configs/convnext/convnext_tiny_ascend.yaml
+++ b/configs/convnext/convnext_tiny_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: 'dynamic'

--- a/configs/convnextv2/convnextv2_tiny_ascend.yaml
+++ b/configs/convnextv2/convnextv2_tiny_ascend.yaml
@@ -52,7 +52,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.049
 loss_scale_type: 'auto'

--- a/configs/crossvit/crossvit_15_ascend.yaml
+++ b/configs/crossvit/crossvit_15_ascend.yaml
@@ -57,7 +57,6 @@ cycle_decay: 1
 # optimizer
 opt: 'adamw'
 weight_decay: 0.05
-filter_bias_and_bn: True
 loss_scale: 512
 use_nesterov: False
 eps: 1e-8

--- a/configs/crossvit/crossvit_18_ascend.yaml
+++ b/configs/crossvit/crossvit_18_ascend.yaml
@@ -55,7 +55,6 @@ decay_rate: 0.1
 # optimizer
 opt: 'adamw'
 weight_decay: 0.05
-filter_bias_and_bn: True
 loss_scale: 1024
 drop_overflow_update: True
 loss_scale_type: 'dynamic'

--- a/configs/crossvit/crossvit_9_ascend.yaml
+++ b/configs/crossvit/crossvit_9_ascend.yaml
@@ -54,7 +54,6 @@ decay_rate: 0.1
 # optimizer
 opt: 'adamw'
 weight_decay: 0.05
-filter_bias_and_bn: True
 loss_scale_type: 'dynamic'
 drop_overflow_update: True
 use_nesterov: False

--- a/configs/densenet/densenet_121_ascend.yaml
+++ b/configs/densenet/densenet_121_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_121_gpu.yaml
+++ b/configs/densenet/densenet_121_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_161_ascend.yaml
+++ b/configs/densenet/densenet_161_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_161_gpu.yaml
+++ b/configs/densenet/densenet_161_gpu.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_169_ascend.yaml
+++ b/configs/densenet/densenet_169_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_169_gpu.yaml
+++ b/configs/densenet/densenet_169_gpu.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_201_ascend.yaml
+++ b/configs/densenet/densenet_201_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/densenet/densenet_201_gpu.yaml
+++ b/configs/densenet/densenet_201_gpu.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/dpn/dpn107_ascend.yaml
+++ b/configs/dpn/dpn107_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'SGD'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/dpn/dpn131_ascend.yaml
+++ b/configs/dpn/dpn131_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'SGD'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/dpn/dpn92_ascend.yaml
+++ b/configs/dpn/dpn92_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'SGD'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/dpn/dpn98_ascend.yaml
+++ b/configs/dpn/dpn98_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'SGD'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/edgenext/edgenext_base_ascend.yaml
+++ b/configs/edgenext/edgenext_base_ascend.yaml
@@ -58,7 +58,6 @@ decay_epochs: 330
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/edgenext/edgenext_small_ascend.yaml
+++ b/configs/edgenext/edgenext_small_ascend.yaml
@@ -57,7 +57,6 @@ decay_epochs: 330
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/edgenext/edgenext_x_small_ascend.yaml
+++ b/configs/edgenext/edgenext_x_small_ascend.yaml
@@ -57,7 +57,6 @@ decay_epochs: 330
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/edgenext/edgenext_xx_small_ascend.yaml
+++ b/configs/edgenext/edgenext_xx_small_ascend.yaml
@@ -56,7 +56,6 @@ decay_epochs: 330
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/efficientnet/efficientnet_b0_ascend.yaml
+++ b/configs/efficientnet/efficientnet_b0_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 445
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale_type: 'dynamic'

--- a/configs/efficientnet/efficientnet_b1_ascend.yaml
+++ b/configs/efficientnet/efficientnet_b1_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 430
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale_type: 'dynamic'

--- a/configs/ghostnet/ghostnet_050_ascend.yaml
+++ b/configs/ghostnet/ghostnet_050_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 580
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale_type: "dynamic"

--- a/configs/ghostnet/ghostnet_100_ascend.yaml
+++ b/configs/ghostnet/ghostnet_100_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 580
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale_type: "dynamic"

--- a/configs/ghostnet/ghostnet_130_ascend.yaml
+++ b/configs/ghostnet/ghostnet_130_ascend.yaml
@@ -47,7 +47,6 @@ decay_epochs: 580
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale_type: "dynamic"

--- a/configs/googlenet/googlenet_ascend.yaml
+++ b/configs/googlenet/googlenet_ascend.yaml
@@ -44,7 +44,6 @@ warmup_epochs: 5
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/halonet/halonet_50t_ascend.yaml
+++ b/configs/halonet/halonet_50t_ascend.yaml
@@ -43,7 +43,6 @@ val_amp_level: 'O2'
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 weight_decay: 0.04
 loss_scale: 1024
 use_nesterov: False

--- a/configs/hrnet/hrnet_w32_ascend.yaml
+++ b/configs/hrnet/hrnet_w32_ascend.yaml
@@ -52,4 +52,3 @@ decay_epochs: 280
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True

--- a/configs/hrnet/hrnet_w48_ascend.yaml
+++ b/configs/hrnet/hrnet_w48_ascend.yaml
@@ -52,4 +52,3 @@ decay_epochs: 280
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True

--- a/configs/inceptionv3/inception_v3_ascend.yaml
+++ b/configs/inceptionv3/inception_v3_ascend.yaml
@@ -47,7 +47,6 @@ warmup_epochs: 5
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/inceptionv4/inception_v4_ascend.yaml
+++ b/configs/inceptionv4/inception_v4_ascend.yaml
@@ -46,7 +46,6 @@ warmup_epochs: 5
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/mixnet/mixnet_l_ascend.yaml
+++ b/configs/mixnet/mixnet_l_ascend.yaml
@@ -48,7 +48,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale_type: "dynamic"

--- a/configs/mixnet/mixnet_m_ascend.yaml
+++ b/configs/mixnet/mixnet_m_ascend.yaml
@@ -50,7 +50,6 @@ warmup_epochs: 15
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale: 1024

--- a/configs/mixnet/mixnet_s_ascend.yaml
+++ b/configs/mixnet/mixnet_s_ascend.yaml
@@ -49,7 +49,6 @@ warmup_epochs: 15
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_0.5_ascend.yaml
+++ b/configs/mnasnet/mnasnet_0.5_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 395
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_0.75_ascend.yaml
+++ b/configs/mnasnet/mnasnet_0.75_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 345
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_0.75_gpu.yaml
+++ b/configs/mnasnet/mnasnet_0.75_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 345
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_1.0_ascend.yaml
+++ b/configs/mnasnet/mnasnet_1.0_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 445
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_1.0_gpu.yaml
+++ b/configs/mnasnet/mnasnet_1.0_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 445
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_1.3_ascend.yaml
+++ b/configs/mnasnet/mnasnet_1.3_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 395
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_1.4_ascend.yaml
+++ b/configs/mnasnet/mnasnet_1.4_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 395
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mnasnet/mnasnet_1.4_gpu.yaml
+++ b/configs/mnasnet/mnasnet_1.4_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 395
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale: 256

--- a/configs/mobilenetv1/mobilenet_v1_0.25_ascend.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.25_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_0.25_gpu.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.25_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_0.5_ascend.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.5_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_0.5_gpu.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.5_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_0.75_ascend.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.75_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_0.75_gpu.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_0.75_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_1.0_ascend.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_1.0_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv1/mobilenet_v1_1.0_gpu.yaml
+++ b/configs/mobilenetv1/mobilenet_v1_1.0_gpu.yaml
@@ -44,7 +44,6 @@ decay_epochs: 198
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv2/mobilenet_v2_0.75_ascend.yaml
+++ b/configs/mobilenetv2/mobilenet_v2_0.75_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 396
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00003
 loss_scale: 1024

--- a/configs/mobilenetv2/mobilenet_v2_1.0_ascend.yaml
+++ b/configs/mobilenetv2/mobilenet_v2_1.0_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 316
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/mobilenetv2/mobilenet_v2_1.4_ascend.yaml
+++ b/configs/mobilenetv2/mobilenet_v2_1.4_ascend.yaml
@@ -45,7 +45,7 @@ decay_epochs: 296
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/mobilenetv3/mobilenet_v3_large_ascend.yaml
+++ b/configs/mobilenetv3/mobilenet_v3_large_ascend.yaml
@@ -45,7 +45,7 @@ decay_epochs: 416
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale: 1024

--- a/configs/mobilenetv3/mobilenet_v3_small_ascend.yaml
+++ b/configs/mobilenetv3/mobilenet_v3_small_ascend.yaml
@@ -46,7 +46,7 @@ decay_epochs: 466
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00002
 loss_scale: 1024

--- a/configs/mobilevit/mobilevit_small_ascend.yaml
+++ b/configs/mobilevit/mobilevit_small_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 430
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.01
 use_nesterov: False

--- a/configs/mobilevit/mobilevit_x_small_ascend.yaml
+++ b/configs/mobilevit/mobilevit_x_small_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 430
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.01
 use_nesterov: False

--- a/configs/mobilevit/mobilevit_xx_small_ascend.yaml
+++ b/configs/mobilevit/mobilevit_xx_small_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 410
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.01
 use_nesterov: False

--- a/configs/nasnet/nasnet_a_4x1056_ascend.yaml
+++ b/configs/nasnet/nasnet_a_4x1056_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 445
 
 # optimizer
 opt: 'rmsprop'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1e-5
 loss_scale_type: 'dynamic'

--- a/configs/pit/pit_b_ascend.yaml
+++ b/configs/pit/pit_b_ascend.yaml
@@ -53,7 +53,6 @@ warmup_factor: 0.002
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "auto"

--- a/configs/pit/pit_s_ascend.yaml
+++ b/configs/pit/pit_s_ascend.yaml
@@ -53,7 +53,6 @@ warmup_factor: 0.002
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "dynamic"

--- a/configs/pit/pit_ti_ascend.yaml
+++ b/configs/pit/pit_ti_ascend.yaml
@@ -50,7 +50,6 @@ warmup_epochs: 10
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "auto"

--- a/configs/pit/pit_xs_ascend.yaml
+++ b/configs/pit/pit_xs_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 10
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "dynamic"

--- a/configs/poolformer/poolformer_s12_ascend.yaml
+++ b/configs/poolformer/poolformer_s12_ascend.yaml
@@ -54,7 +54,6 @@ decay_rate: 0.1
 
 # optimizer
 opt: 'AdamW'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/pvt/pvt_large_ascend.yaml
+++ b/configs/pvt/pvt_large_ascend.yaml
@@ -52,5 +52,4 @@ decay_epochs: 390
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 300
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/pvt/pvt_medium_ascend.yaml
+++ b/configs/pvt/pvt_medium_ascend.yaml
@@ -52,5 +52,4 @@ decay_epochs: 390
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/pvt/pvt_small_ascend.yaml
+++ b/configs/pvt/pvt_small_ascend.yaml
@@ -52,5 +52,4 @@ decay_epochs: 390
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/pvt/pvt_tiny_ascend.yaml
+++ b/configs/pvt/pvt_tiny_ascend.yaml
@@ -52,5 +52,4 @@ decay_epochs: 440
 opt: 'adamw'
 weight_decay: 0.05
 loss_scale: 1024
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/pvtv2/pvt_v2_b0_ascend.yaml
+++ b/configs/pvtv2/pvt_v2_b0_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 10
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "dynamic"

--- a/configs/pvtv2/pvt_v2_b1_ascend.yaml
+++ b/configs/pvtv2/pvt_v2_b1_ascend.yaml
@@ -51,7 +51,6 @@ warmup_epochs: 10
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "dynamic"

--- a/configs/pvtv2/pvt_v2_b2_ascend.yaml
+++ b/configs/pvtv2/pvt_v2_b2_ascend.yaml
@@ -50,7 +50,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "dynamic"

--- a/configs/pvtv2/pvt_v2_b3_ascend.yaml
+++ b/configs/pvtv2/pvt_v2_b3_ascend.yaml
@@ -50,7 +50,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "auto"

--- a/configs/pvtv2/pvt_v2_b4_ascend.yaml
+++ b/configs/pvtv2/pvt_v2_b4_ascend.yaml
@@ -50,7 +50,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: "adamw"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale_type: "auto"

--- a/configs/regnet/regnet_x_200mf_ascend.yaml
+++ b/configs/regnet/regnet_x_200mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_x_400mf_ascend.yaml
+++ b/configs/regnet/regnet_x_400mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_x_600mf_ascend.yaml
+++ b/configs/regnet/regnet_x_600mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_x_800mf_ascend.yaml
+++ b/configs/regnet/regnet_x_800mf_ascend.yaml
@@ -52,4 +52,3 @@ momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 128
 use_nesterov: False
-filter_bias_and_bn: True

--- a/configs/regnet/regnet_y_16gf_ascend.yaml
+++ b/configs/regnet/regnet_y_16gf_ascend.yaml
@@ -55,7 +55,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 4e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_y_200mf_ascend.yaml
+++ b/configs/regnet/regnet_y_200mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_y_400mf_ascend.yaml
+++ b/configs/regnet/regnet_y_400mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_y_600mf_ascend.yaml
+++ b/configs/regnet/regnet_y_600mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/regnet/regnet_y_800mf_ascend.yaml
+++ b/configs/regnet/regnet_y_800mf_ascend.yaml
@@ -49,7 +49,6 @@ opt: 'momentum'
 momentum: 0.9
 weight_decay: 5e-5
 use_nesterov: False
-filter_bias_and_bn: True
 
 # amp
 amp_level: 'O2'

--- a/configs/repmlp/repmlp_t224_ascend.yaml
+++ b/configs/repmlp/repmlp_t224_ascend.yaml
@@ -55,7 +55,6 @@ decay_rate: 0.01
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 2e-05
 loss_scale: 1024

--- a/configs/repvgg/repvgg_a0_ascend.yaml
+++ b/configs/repvgg/repvgg_a0_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 390
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_a1_ascend.yaml
+++ b/configs/repvgg/repvgg_a1_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_a2_ascend.yaml
+++ b/configs/repvgg/repvgg_a2_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b0_ascend.yaml
+++ b/configs/repvgg/repvgg_b0_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b1_ascend.yaml
+++ b/configs/repvgg/repvgg_b1_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b1g2_ascend.yaml
+++ b/configs/repvgg/repvgg_b1g2_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b1g4_ascend.yaml
+++ b/configs/repvgg/repvgg_b1g4_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b2_ascend.yaml
+++ b/configs/repvgg/repvgg_b2_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b2g4_ascend.yaml
+++ b/configs/repvgg/repvgg_b2g4_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/repvgg/repvgg_b3_ascend.yaml
+++ b/configs/repvgg/repvgg_b3_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 235
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/res2net/res2net_101_ascend.yaml
+++ b/configs/res2net/res2net_101_ascend.yaml
@@ -49,7 +49,6 @@ decay_epochs: 30
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_101_gpu.yaml
+++ b/configs/res2net/res2net_101_gpu.yaml
@@ -49,7 +49,6 @@ decay_epochs: 295
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_101_v1b_ascend.yaml
+++ b/configs/res2net/res2net_101_v1b_ascend.yaml
@@ -48,7 +48,6 @@ decay_epochs: 196
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_101_v1b_gpu.yaml
+++ b/configs/res2net/res2net_101_v1b_gpu.yaml
@@ -49,7 +49,6 @@ decay_epochs: 295
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_50_ascend.yaml
+++ b/configs/res2net/res2net_50_ascend.yaml
@@ -48,7 +48,6 @@ decay_epochs: 196
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_50_gpu.yaml
+++ b/configs/res2net/res2net_50_gpu.yaml
@@ -49,7 +49,6 @@ decay_epochs: 295
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_50_v1b_ascend.yaml
+++ b/configs/res2net/res2net_50_v1b_ascend.yaml
@@ -49,7 +49,6 @@ decay_epochs: 295
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/res2net/res2net_50_v1b_gpu.yaml
+++ b/configs/res2net/res2net_50_v1b_gpu.yaml
@@ -49,7 +49,6 @@ decay_epochs: 295
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnest/resnest101_ascend.yaml
+++ b/configs/resnest/resnest101_ascend.yaml
@@ -50,7 +50,6 @@ decay_epochs: 345
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00009
 loss_scale_type: "auto"

--- a/configs/resnest/resnest50_ascend.yaml
+++ b/configs/resnest/resnest50_ascend.yaml
@@ -49,7 +49,6 @@ decay_epochs: 345
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale_type: "dynamic"

--- a/configs/resnet/resnet_101_ascend.yaml
+++ b/configs/resnet/resnet_101_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_101_gpu.yaml
+++ b/configs/resnet/resnet_101_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_152_ascend.yaml
+++ b/configs/resnet/resnet_152_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_152_gpu.yaml
+++ b/configs/resnet/resnet_152_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_18_ascend.yaml
+++ b/configs/resnet/resnet_18_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_18_gpu.yaml
+++ b/configs/resnet/resnet_18_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_34_ascend.yaml
+++ b/configs/resnet/resnet_34_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_34_gpu.yaml
+++ b/configs/resnet/resnet_34_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_50_ascend.yaml
+++ b/configs/resnet/resnet_50_ascend.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnet/resnet_50_gpu.yaml
+++ b/configs/resnet/resnet_50_gpu.yaml
@@ -43,7 +43,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnetv2/resnetv2_101_ascend.yaml
+++ b/configs/resnetv2/resnetv2_101_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnetv2/resnetv2_50_ascend.yaml
+++ b/configs/resnetv2/resnetv2_50_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 120
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnext/resnext101_32x4d_ascend.yaml
+++ b/configs/resnext/resnext101_32x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnext/resnext101_64x4d_ascend.yaml
+++ b/configs/resnext/resnext101_64x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnext/resnext152_64x4d_ascend.yaml
+++ b/configs/resnext/resnext152_64x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/resnext/resnext50_32x4d_ascend.yaml
+++ b/configs/resnext/resnext50_32x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/rexnet/rexnet_x09_ascend.yaml
+++ b/configs/rexnet/rexnet_x09_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 395
 
 # optimizer
 opt: "sgd"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1.0e-5
 loss_scale: 1024

--- a/configs/rexnet/rexnet_x10_ascend.yaml
+++ b/configs/rexnet/rexnet_x10_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 395
 
 # optimizer
 opt: "sgd"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1.0e-5
 loss_scale: 1024

--- a/configs/rexnet/rexnet_x13_ascend.yaml
+++ b/configs/rexnet/rexnet_x13_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 395
 
 # optimizer
 opt: "sgd"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1.0e-5
 loss_scale: 1024

--- a/configs/rexnet/rexnet_x15_ascend.yaml
+++ b/configs/rexnet/rexnet_x15_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 370
 
 # optimizer
 opt: "sgd"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1.0e-5
 loss_scale: 1024

--- a/configs/rexnet/rexnet_x20_ascend.yaml
+++ b/configs/rexnet/rexnet_x20_ascend.yaml
@@ -46,7 +46,6 @@ decay_epochs: 370
 
 # optimizer
 opt: "sgd"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 1.0e-5
 loss_scale: 1024

--- a/configs/senet/seresnet18_ascend.yaml
+++ b/configs/senet/seresnet18_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/senet/seresnet34_ascend.yaml
+++ b/configs/senet/seresnet34_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/senet/seresnet50_ascend.yaml
+++ b/configs/senet/seresnet50_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/senet/seresnext26_32x4d_ascend.yaml
+++ b/configs/senet/seresnext26_32x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/senet/seresnext50_32x4d_ascend.yaml
+++ b/configs/senet/seresnext50_32x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 150
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/shufflenetv1/shufflenet_v1_0.5_ascend.yaml
+++ b/configs/shufflenetv1/shufflenet_v1_0.5_ascend.yaml
@@ -42,7 +42,7 @@ decay_epochs: 246
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/shufflenetv1/shufflenet_v1_1.0_ascend.yaml
+++ b/configs/shufflenetv1/shufflenet_v1_1.0_ascend.yaml
@@ -42,7 +42,7 @@ decay_epochs: 246
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/shufflenetv2/shufflenet_v2_0.5_ascend.yaml
+++ b/configs/shufflenetv2/shufflenet_v2_0.5_ascend.yaml
@@ -44,7 +44,7 @@ decay_epochs: 246
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/shufflenetv2/shufflenet_v2_1.0_ascend.yaml
+++ b/configs/shufflenetv2/shufflenet_v2_1.0_ascend.yaml
@@ -44,7 +44,7 @@ decay_epochs: 295
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/shufflenetv2/shufflenet_v2_1.5_ascend.yaml
+++ b/configs/shufflenetv2/shufflenet_v2_1.5_ascend.yaml
@@ -44,7 +44,7 @@ decay_epochs: 295
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/shufflenetv2/shufflenet_v2_2.0_ascend.yaml
+++ b/configs/shufflenetv2/shufflenet_v2_2.0_ascend.yaml
@@ -44,7 +44,7 @@ decay_epochs: 295
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: False
+weight_decay_filter: 'auto'
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/sknet/skresnet18_ascend.yaml
+++ b/configs/sknet/skresnet18_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 195
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/sknet/skresnet34_ascend.yaml
+++ b/configs/sknet/skresnet34_ascend.yaml
@@ -47,7 +47,6 @@ warmup_factor: 0.01
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 128

--- a/configs/sknet/skresnext50_32x4d_ascend.yaml
+++ b/configs/sknet/skresnext50_32x4d_ascend.yaml
@@ -44,7 +44,6 @@ decay_epochs: 195
 
 # optimizer
 opt: "momentum"
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/squeezenet/squeezenet_1.0_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.0_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0001
 loss_scale: 1024

--- a/configs/squeezenet/squeezenet_1.0_gpu.yaml
+++ b/configs/squeezenet/squeezenet_1.0_gpu.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00007
 loss_scale: 1024

--- a/configs/squeezenet/squeezenet_1.1_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.1_ascend.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.0002
 loss_scale: 1024

--- a/configs/squeezenet/squeezenet_1.1_gpu.yaml
+++ b/configs/squeezenet/squeezenet_1.1_gpu.yaml
@@ -45,7 +45,6 @@ decay_epochs: 200
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00007
 loss_scale: 1024

--- a/configs/swintransformer/swin_tiny_ascend.yaml
+++ b/configs/swintransformer/swin_tiny_ascend.yaml
@@ -55,5 +55,4 @@ lr_epoch_stair: False
 # optimizer
 opt: "adamw"
 weight_decay: 0.025
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/swintransformerv2/swinv2_tiny_window8_ascend.yaml
+++ b/configs/swintransformerv2/swinv2_tiny_window8_ascend.yaml
@@ -49,7 +49,6 @@ warmup_epochs: 20
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.05
 loss_scale: 1024

--- a/configs/vgg/vgg11_ascend.yaml
+++ b/configs/vgg/vgg11_ascend.yaml
@@ -44,7 +44,6 @@ warmup_epochs: 2
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/vgg/vgg13_ascend.yaml
+++ b/configs/vgg/vgg13_ascend.yaml
@@ -44,7 +44,6 @@ warmup_epochs: 2
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/vgg/vgg16_ascend.yaml
+++ b/configs/vgg/vgg16_ascend.yaml
@@ -44,7 +44,6 @@ warmup_epochs: 2
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/vgg/vgg19_ascend.yaml
+++ b/configs/vgg/vgg19_ascend.yaml
@@ -44,7 +44,6 @@ warmup_epochs: 2
 
 # optimizer
 opt: 'momentum'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00004
 loss_scale: 1024

--- a/configs/vit/vit_b32_224_ascend.yaml
+++ b/configs/vit/vit_b32_224_ascend.yaml
@@ -57,5 +57,4 @@ lr_epoch_stair: False
 # optimizer
 opt: "adamw"
 weight_decay: 0.025
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/vit/vit_l16_224_ascend.yaml
+++ b/configs/vit/vit_l16_224_ascend.yaml
@@ -57,5 +57,4 @@ lr_epoch_stair: False
 # optimizer
 opt: "adamw"
 weight_decay: 0.05
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/vit/vit_l32_224_ascend.yaml
+++ b/configs/vit/vit_l32_224_ascend.yaml
@@ -57,5 +57,4 @@ lr_epoch_stair: False
 # optimizer
 opt: "adamw"
 weight_decay: 0.025
-filter_bias_and_bn: True
 use_nesterov: False

--- a/configs/volo/volo_d1_ascend.yaml
+++ b/configs/volo/volo_d1_ascend.yaml
@@ -60,7 +60,6 @@ decay_rate: 0.1
 opt: 'adamw'
 weight_decay: 0.05
 momentum: 0.9
-filter_bias_and_bn: True
 loss_scale_type: 'dynamic'
 loss_scale: 1024
 use_nesterov: False

--- a/configs/volo/volo_d2_ascend.yaml
+++ b/configs/volo/volo_d2_ascend.yaml
@@ -60,7 +60,6 @@ decay_rate: 0.1
 opt: 'adamw'
 weight_decay: 0.05
 momentum: 0.9
-filter_bias_and_bn: True
 loss_scale_type: 'dynamic'
 loss_scale: 2048
 use_nesterov: False

--- a/configs/volo/volo_d3_ascend.yaml
+++ b/configs/volo/volo_d3_ascend.yaml
@@ -61,7 +61,6 @@ decay_rate: 0.1
 opt: 'adamw'
 weight_decay: 0.05
 momentum: 0.9
-filter_bias_and_bn: True
 loss_scale_type: 'dynamic'
 loss_scale: 1024
 use_nesterov: False

--- a/configs/volo/volo_d4_ascend.yaml
+++ b/configs/volo/volo_d4_ascend.yaml
@@ -60,7 +60,6 @@ decay_rate: 0.1
 opt: 'adamw'
 weight_decay: 0.05
 momentum: 0.9
-filter_bias_and_bn: True
 loss_scale_type: 'dynamic'
 loss_scale: 1024
 use_nesterov: False

--- a/configs/xception/xception_ascend.yaml
+++ b/configs/xception/xception_ascend.yaml
@@ -46,7 +46,6 @@ warmup_epochs: 5
 
 # optimizer
 opt: 'sgd'
-filter_bias_and_bn: True
 momentum: 0.9
 weight_decay: 0.00001
 loss_scale: 1024

--- a/configs/xcit/xcit_tiny_12_p16_ascend.yaml
+++ b/configs/xcit/xcit_tiny_12_p16_ascend.yaml
@@ -52,7 +52,6 @@ decay_rate: 0.1
 
 # optimizer
 opt: 'adamw'
-filter_bias_and_bn: True
 weight_decay: 0.05
 loss_scale: 1024
 use_nesterov: False

--- a/docs/en/tutorials/configuration.md
+++ b/docs/en/tutorials/configuration.md
@@ -354,7 +354,7 @@ Let's use squeezenet_1.0 model as an example to explain how to configure the cor
 
    - opt: name of optimizer.
 
-   - filter_bias_and_bn: filter Bias and BatchNorm.
+   - weight_decay_filter: weight decay filter (filter parameters from weight decay).
 
    - momentum: Hyperparameter of type float, means momentum for the moving average.
 
@@ -368,7 +368,7 @@ Let's use squeezenet_1.0 model as an example to explain how to configure the cor
 
     ```yaml
     opt: 'momentum'
-    filter_bias_and_bn: True
+    weight_decay_filter: 'norm_and_bias'
     momentum: 0.9
     weight_decay: 0.00007
     loss_scale: 1024
@@ -379,7 +379,7 @@ Let's use squeezenet_1.0 model as an example to explain how to configure the cor
 3. Parse parameter setting
 
     ```shell
-    python train.py ... --opt momentum --filter_bias_and_bn True --weight_decay 0.00007 \
+    python train.py ... --opt momentum --weight_decay_filter 'norm_and_bias' --weight_decay 0.00007 \
         --loss_scale 1024 --use_nesterov False ...
     ```
 
@@ -395,7 +395,7 @@ Let's use squeezenet_1.0 model as an example to explain how to configure the cor
                 weight_decay=args.weight_decay,
                 momentum=args.momentum,
                 nesterov=args.use_nesterov,
-                filter_bias_and_bn=args.filter_bias_and_bn,
+                weight_decay_filter=args.weight_decay_filter,
                 loss_scale=args.loss_scale,
                 checkpoint_path=opt_ckpt_path,
                 eps=args.eps
@@ -407,7 +407,7 @@ Let's use squeezenet_1.0 model as an example to explain how to configure the cor
                 weight_decay=args.weight_decay,
                 momentum=args.momentum,
                 nesterov=args.use_nesterov,
-                filter_bias_and_bn=args.filter_bias_and_bn,
+                weight_decay_filter=args.weight_decay_filter,
                 checkpoint_path=opt_ckpt_path,
                 eps=args.eps
             )

--- a/docs/zh/tutorials/configuration.md
+++ b/docs/zh/tutorials/configuration.md
@@ -354,7 +354,7 @@
 
    - opt：优化器名称。
 
-   - filter_bias_and_bn：参数中是否包含bias，gamma或者beta。
+   - weight_decay_filter：权重衰减过滤器 （过滤一些参数， 使其在跟新时不做权重衰减）。
 
    - momentum：移动平均的动量。
 
@@ -368,7 +368,7 @@
 
     ```yaml
     opt: 'momentum'
-    filter_bias_and_bn: True
+    weight_decay_filter: 'norm_and_bias'
     momentum: 0.9
     weight_decay: 0.00007
     loss_scale: 1024
@@ -379,7 +379,7 @@
 3. parse参数设置
 
     ```shell
-    python train.py ... --opt momentum --filter_bias_and_bn True --weight_decay 0.00007 \
+    python train.py ... --opt momentum --weight_decay_filter 'norm_and_bias" --weight_decay 0.00007 \
         --loss_scale 1024 --use_nesterov False ...
     ```
 
@@ -395,7 +395,7 @@
                 weight_decay=args.weight_decay,
                 momentum=args.momentum,
                 nesterov=args.use_nesterov,
-                filter_bias_and_bn=args.filter_bias_and_bn,
+                weight_decay_filter=args.weight_decay_filter,
                 loss_scale=args.loss_scale,
                 checkpoint_path=opt_ckpt_path,
                 eps=args.eps
@@ -407,7 +407,7 @@
                 weight_decay=args.weight_decay,
                 momentum=args.momentum,
                 nesterov=args.use_nesterov,
-                filter_bias_and_bn=args.filter_bias_and_bn,
+                weight_decay_filter=args.weight_decay_filter,
                 checkpoint_path=opt_ckpt_path,
                 eps=args.eps
             )

--- a/examples/finetune/finetune.py
+++ b/examples/finetune/finetune.py
@@ -283,7 +283,7 @@ def finetune_train(args):
         weight_decay=args.weight_decay,
         momentum=args.momentum,
         nesterov=args.use_nesterov,
-        filter_bias_and_bn=args.filter_bias_and_bn,
+        weight_decay_filter=args.weight_decay_filter,
         loss_scale=optimizer_loss_scale,
         checkpoint_path=opt_ckpt_path,
         eps=args.eps,

--- a/examples/seg/deeplabv3/config/deeplabv3_s16_dilated_resnet101.yaml
+++ b/examples/seg/deeplabv3/config/deeplabv3_s16_dilated_resnet101.yaml
@@ -51,7 +51,7 @@ drop_overflow_update: False
 loss_scale: 3072.0
 momentum: 0.9
 weight_decay: 0.0001
-filter_bias_and_bn: False
+weight_decay_filter": 'auto'
 gradient_accumulation_steps: 1
 
 # callbacks

--- a/examples/seg/deeplabv3/config/deeplabv3_s8_dilated_resnet101.yaml
+++ b/examples/seg/deeplabv3/config/deeplabv3_s8_dilated_resnet101.yaml
@@ -51,7 +51,7 @@ drop_overflow_update: False
 loss_scale: 2048.0
 momentum: 0.9
 weight_decay: 0.0001
-filter_bias_and_bn: False
+weight_decay_filter": 'auto'
 gradient_accumulation_steps: 1
 
 # callbacks

--- a/examples/seg/deeplabv3/config/deeplabv3plus_s16_dilated_resnet101.yaml
+++ b/examples/seg/deeplabv3/config/deeplabv3plus_s16_dilated_resnet101.yaml
@@ -51,7 +51,7 @@ drop_overflow_update: False
 loss_scale: 3072.0
 momentum: 0.9
 weight_decay: 0.0001
-filter_bias_and_bn: False
+weight_decay_filter": 'auto'
 gradient_accumulation_steps: 1
 
 # callbacks

--- a/examples/seg/deeplabv3/config/deeplabv3plus_s8_dilated_resnet101.yaml
+++ b/examples/seg/deeplabv3/config/deeplabv3plus_s8_dilated_resnet101.yaml
@@ -51,7 +51,7 @@ drop_overflow_update: False
 loss_scale: 2048.0
 momentum: 0.9
 weight_decay: 0.0001
-filter_bias_and_bn: False
+weight_decay_filter": 'auto'
 gradient_accumulation_steps: 1
 
 # callbacks

--- a/examples/seg/deeplabv3/train.py
+++ b/examples/seg/deeplabv3/train.py
@@ -118,7 +118,7 @@ def train(args):
         lr=lr_scheduler,
         weight_decay=args.weight_decay,
         momentum=args.momentum,
-        filter_bias_and_bn=args.filter_bias_and_bn,
+        weight_decay_filter=args.weight_decay_filter,
         loss_scale=optimizer_loss_scale,
     )
 

--- a/mindcv/optim/optim_factory.py
+++ b/mindcv/optim/optim_factory.py
@@ -1,7 +1,11 @@
 """ optim factory """
+import collections
 import logging
 import os
-from typing import Optional
+import re
+from collections import defaultdict
+from itertools import chain, islice
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
 
 from mindspore import load_checkpoint, load_param_into_net, nn
 
@@ -37,6 +41,152 @@ def init_group_params(params, weight_decay, weight_decay_filter, no_weight_decay
     ]
 
 
+def param_groups_layer_decay(
+    model: nn.Cell,
+    lr: Optional[float] = 1e-3,
+    weight_decay: float = 0.05,
+    no_weight_decay_list: Tuple[str] = (),
+    layer_decay: float = 0.75,
+):
+    """
+    Parameter groups for layer-wise lr decay & weight decay
+    """
+    no_weight_decay_list = set(no_weight_decay_list)
+    param_group_names = {}  # NOTE for debugging
+    param_groups = {}
+    if hasattr(model, "group_matcher"):
+        layer_map = group_with_matcher(model.trainable_params(), model.group_matcher(coarse=False), reverse=True)
+    else:
+        layer_map = _layer_map(model)
+
+    num_layers = max(layer_map.values()) + 1
+    layer_max = num_layers - 1
+    layer_scales = list(layer_decay ** (layer_max - i) for i in range(num_layers))
+
+    for name, param in model.parameters_and_names():
+        if not param.requires_grad:
+            continue
+
+        # no decay: all 1D parameters and model specific ones
+        if param.ndim == 1 or name in no_weight_decay_list:
+            g_decay = "no_decay"
+            this_decay = 0.0
+        else:
+            g_decay = "decay"
+            this_decay = weight_decay
+
+        layer_id = layer_map.get(name, layer_max)
+        group_name = "layer_%d_%s" % (layer_id, g_decay)
+
+        if group_name not in param_groups:
+            this_scale = layer_scales[layer_id]
+            param_group_names[group_name] = {
+                "lr": [learning_rate * this_scale for learning_rate in lr],
+                "weight_decay": this_decay,
+                "param_names": [],
+            }
+            param_groups[group_name] = {
+                "lr": [learning_rate * this_scale for learning_rate in lr],
+                "weight_decay": this_decay,
+                "params": [],
+            }
+
+        param_group_names[group_name]["param_names"].append(name)
+        param_groups[group_name]["params"].append(param)
+
+    return list(param_groups.values())
+
+
+MATCH_PREV_GROUP = (99999,)
+
+
+def group_with_matcher(
+    named_objects: Iterator[Tuple[str, Any]], group_matcher: Union[Dict, Callable], reverse: bool = False
+):
+    if isinstance(group_matcher, dict):
+        # dictionary matcher contains a dict of raw-string regex expr that must be compiled
+        compiled = []
+        for group_ordinal, (_, mspec) in enumerate(group_matcher.items()):
+            if mspec is None:
+                continue
+            # map all matching specifications into 3-tuple (compiled re, prefix, suffix)
+            if isinstance(mspec, (tuple, list)):
+                # multi-entry match specifications require each sub-spec to be a 2-tuple (re, suffix)
+                for sspec in mspec:
+                    compiled += [(re.compile(sspec[0]), (group_ordinal,), sspec[1])]
+            else:
+                compiled += [(re.compile(mspec), (group_ordinal,), None)]
+        group_matcher = compiled
+
+    def _get_grouping(name):
+        if isinstance(group_matcher, (list, tuple)):
+            for match_fn, prefix, suffix in group_matcher:
+                r = match_fn.match(name)
+                if r:
+                    parts = (prefix, r.groups(), suffix)
+                    # map all tuple elem to int for numeric sort, filter out None entries
+                    return tuple(map(float, chain.from_iterable(filter(None, parts))))
+            return (float("inf"),)  # un-matched layers (neck, head) mapped to largest ordinal
+        else:
+            ord = group_matcher(name)
+            if not isinstance(ord, collections.abc.Iterable):
+                return (ord,)
+            return tuple(ord)
+
+    grouping = defaultdict(list)
+    for param in named_objects:
+        grouping[_get_grouping(param.name)].append(param.name)
+    # remap to integers
+    layer_id_to_param = defaultdict(list)
+    lid = -1
+    for k in sorted(filter(lambda x: x is not None, grouping.keys())):
+        if lid < 0 or k[-1] != MATCH_PREV_GROUP[0]:
+            lid += 1
+        layer_id_to_param[lid].extend(grouping[k])
+
+    if reverse:
+        # output reverse mapping
+        param_to_layer_id = {}
+        for lid, lm in layer_id_to_param.items():
+            for n in lm:
+                param_to_layer_id[n] = lid
+        return param_to_layer_id
+
+    return layer_id_to_param
+
+
+def _group(it, size):
+    it = iter(it)
+    return iter(lambda: tuple(islice(it, size)), ())
+
+
+def _layer_map(model, layers_per_group=12, num_groups=None):
+    def _in_head(n, hp):
+        if not hp:
+            return True
+        elif isinstance(hp, (tuple, list)):
+            return any([n.startswith(hpi) for hpi in hp])
+        else:
+            return n.startswith(hp)
+
+    # attention: need to add pretrained_cfg attr to model
+    head_prefix = getattr(model, "pretrained_cfg", {}).get("classifier", None)
+    names_trunk = []
+    names_head = []
+    for n, _ in model.parameters_and_names():
+        names_head.append(n) if _in_head(n, head_prefix) else names_trunk.append(n)
+
+    # group non-head layers
+    num_trunk_layers = len(names_trunk)
+    if num_groups is not None:
+        layers_per_group = -(num_trunk_layers // -num_groups)
+    names_trunk = list(_group(names_trunk, layers_per_group))
+    num_trunk_groups = len(names_trunk)
+    layer_map = {n: i for i, l in enumerate(names_trunk) for n in l}
+    layer_map.update({n: num_trunk_groups for n in names_head})
+    return layer_map
+
+
 def create_optimizer(
     model_or_params,
     opt: str = "adam",
@@ -45,6 +195,7 @@ def create_optimizer(
     momentum: float = 0.9,
     nesterov: bool = False,
     weight_decay_filter: str = "disable",
+    layer_decay: Optional[float] = None,
     loss_scale: float = 1.0,
     schedule_decay: float = 4e-3,
     checkpoint_path: str = "",
@@ -54,9 +205,9 @@ def create_optimizer(
     r"""Creates optimizer by name.
 
     Args:
-        params: network parameters. Union[list[Parameter],list[dict]], which must be the list of parameters
-            or list of dicts. When the list element is a dictionary, the key of the dictionary can be
-            "params", "lr", "weight_decay","grad_centralization" and "order_params".
+        model_or_params: network or network parameters. Union[list[Parameter],list[dict], nn.Cell], which must be
+            the list of parameters or list of dicts or nn.Cell. When the list element is a dictionary, the key of
+            the dictionary can be "params", "lr", "weight_decay","grad_centralization" and "order_params".
         opt: wrapped optimizer. You could choose like 'sgd', 'nesterov', 'momentum', 'adam', 'adamw', 'lion',
             'rmsprop', 'adagrad', 'lamb'. 'adam' is the default choose for convolution-based networks.
             'adamw' is recommended for ViT-based networks. Default: 'adam'.
@@ -73,6 +224,7 @@ def create_optimizer(
             - "auto": We do not apply weight decay filtering to any parameters. However, MindSpore currently
                     automatically filters the parameters of Norm layer from weight decay.
             - "norm_and_bias": Filter the paramters of Norm layer and Bias from weight decay.
+        layer_decay: for apply layer-wise learning rate decay.
         loss_scale: A floating point value for the loss scale, which must be larger than 0.0. Default: 1.0.
 
     Returns:
@@ -95,6 +247,15 @@ def create_optimizer(
             "when creating an mindspore.nn.Optimizer instance. "
             "NOTE: mindspore.nn.Optimizer will filter Norm parmas from weight decay. "
         )
+    elif layer_decay is not None and isinstance(model_or_params, nn.Cell):
+        params = param_groups_layer_decay(
+            model_or_params,
+            lr=lr,
+            weight_decay=weight_decay,
+            layer_decay=layer_decay,
+            no_weight_decay_list=no_weight_decay,
+        )
+        weight_decay = 0.0
     elif weight_decay_filter == "disable" or "norm_and_bias":
         params = init_group_params(params, weight_decay, weight_decay_filter, no_weight_decay)
         weight_decay = 0.0

--- a/tests/modules/parallel/test_parallel_optim.py
+++ b/tests/modules/parallel/test_parallel_optim.py
@@ -44,8 +44,8 @@ class SimpleCNN(nn.Cell):
 
 @pytest.mark.parametrize("opt", ["sgd", "momentum"])
 @pytest.mark.parametrize("nesterov", [True, False])
-@pytest.mark.parametrize("filter_bias_and_bn", [True, False])
-def test_sgd_optimizer(opt, nesterov, filter_bias_and_bn):
+@pytest.mark.parametrize("weight_decay_filter", ["auto", "disable", "norm_and_bias"])
+def test_sgd_optimizer(opt, nesterov, weight_decay_filter):
     init("nccl")
     device_num = get_group_size()
     rank_id = get_rank()  # noqa: F841
@@ -64,7 +64,7 @@ def test_sgd_optimizer(opt, nesterov, filter_bias_and_bn):
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=nesterov,
-        filter_bias_and_bn=filter_bias_and_bn,
+        weight_decay_filter=weight_decay_filter,
     )
 
     bs = 8
@@ -227,7 +227,7 @@ def test_param_lr_001_filter_bias_and_bn_optimizer():
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=False,
-        filter_bias_and_bn=False,
+        weight_decay_filter="auto",
     )
 
     bs = 8
@@ -273,7 +273,7 @@ def test_param_lr_0001_filter_bias_and_bn_optimizer():
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=False,
-        filter_bias_and_bn=False,
+        weight_decay_filter="auto",
     )
 
     bs = 8
@@ -315,7 +315,7 @@ def test_wrong_momentum_optimizer(momentum):
             momentum=momentum,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -357,7 +357,7 @@ def test_wrong_loss_scale_optimizer(loss_scale):
             momentum=0.9,
             loss_scale=loss_scale,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -400,7 +400,7 @@ def test_wrong_weight_decay_optimizer(weight_decay):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -442,7 +442,7 @@ def test_wrong_lr_optimizer(lr):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -488,7 +488,7 @@ def test_param_lr_01_filter_bias_and_bn_optimizer():
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=False,
-        filter_bias_and_bn=False,
+        weight_decay_filter="auto",
     )
 
     bs = 8
@@ -530,7 +530,7 @@ def test_wrong_opt_optimizer(opt):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -579,7 +579,7 @@ def test_wrong_params_more_optimizer():
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=False,
+            weight_decay_filter="auto",
         )
 
         bs = 8
@@ -627,7 +627,7 @@ def test_wrong_params_input_optimizer():
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=False,
+            weight_decay_filter="auto",
         )
 
         bs = 8
@@ -681,7 +681,7 @@ def test_mode_mult_single_optimizer(mode):
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=False,
-        filter_bias_and_bn=False,
+        weight_decay_filter="auto",
     )
 
     bs = 8

--- a/tests/modules/test_optim.py
+++ b/tests/modules/test_optim.py
@@ -43,8 +43,8 @@ class SimpleCNN(nn.Cell):
 
 @pytest.mark.parametrize("opt", ["sgd", "momentum"])
 @pytest.mark.parametrize("nesterov", [True, False])
-@pytest.mark.parametrize("filter_bias_and_bn", [True, False])
-def test_sgd_optimizer(opt, nesterov, filter_bias_and_bn):
+@pytest.mark.parametrize("weight_decay_filter", ["disable", "auto", "norm_and_bias"])
+def test_sgd_optimizer(opt, nesterov, weight_decay_filter):
     network = SimpleCNN(in_channels=1, num_classes=10)
     net_loss = nn.SoftmaxCrossEntropyWithLogits(sparse=True, reduction="mean")
 
@@ -55,7 +55,7 @@ def test_sgd_optimizer(opt, nesterov, filter_bias_and_bn):
         weight_decay=1e-5,
         momentum=0.9,
         nesterov=nesterov,
-        filter_bias_and_bn=filter_bias_and_bn,
+        weight_decay_filter=weight_decay_filter,
     )
 
     bs = 8
@@ -171,7 +171,7 @@ def test_param_lr_001_filter_bias_and_bn_optimizer():
     ]
     net_loss = nn.SoftmaxCrossEntropyWithLogits(sparse=True, reduction="mean")
     net_opt = create_optimizer(
-        group_params, "adamW", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, filter_bias_and_bn=False
+        group_params, "adamW", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, weight_decay_filter="auto"
     )
 
     bs = 8
@@ -203,7 +203,7 @@ def test_param_lr_0001_filter_bias_and_bn_optimizer():
     ]
     net_loss = nn.SoftmaxCrossEntropyWithLogits(sparse=True, reduction="mean")
     net_opt = create_optimizer(
-        group_params, "adamW", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, filter_bias_and_bn=False
+        group_params, "adamW", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, weight_decay_filter="auto"
     )
 
     bs = 8
@@ -237,7 +237,7 @@ def test_wrong_momentum_optimizer(momentum):
             momentum=momentum,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -271,7 +271,7 @@ def test_wrong_loss_scale_optimizer(loss_scale):
             momentum=0.9,
             loss_scale=loss_scale,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -306,7 +306,7 @@ def test_wrong_weight_decay_optimizer(weight_decay):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -340,7 +340,7 @@ def test_wrong_lr_optimizer(lr):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -372,7 +372,7 @@ def test_param_lr_01_filter_bias_and_bn_optimizer():
     ]
     net_loss = nn.SoftmaxCrossEntropyWithLogits(sparse=True, reduction="mean")
     net_opt = create_optimizer(
-        group_params, "momentum", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, filter_bias_and_bn=False
+        group_params, "momentum", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, weight_decay_filter="auto"
     )
 
     bs = 8
@@ -406,7 +406,7 @@ def test_wrong_opt_optimizer(opt):
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=True,
+            weight_decay_filter="disable",
         )
 
         bs = 8
@@ -447,7 +447,7 @@ def test_wrong_params_more_optimizer():
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=False,
+            weight_decay_filter="auto",
         )
 
         bs = 8
@@ -487,7 +487,7 @@ def test_wrong_params_input_optimizer():
             momentum=0.9,
             loss_scale=1.0,
             nesterov=False,
-            filter_bias_and_bn=False,
+            weight_decay_filter="auto",
         )
 
         bs = 8
@@ -527,7 +527,7 @@ def test_mode_mult_single_optimizer(mode):
     ]
     net_loss = nn.SoftmaxCrossEntropyWithLogits(sparse=True, reduction="mean")
     net_opt = create_optimizer(
-        group_params, "momentum", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, filter_bias_and_bn=False
+        group_params, "momentum", lr=0.01, weight_decay=1e-5, momentum=0.9, nesterov=False, weight_decay_filter="auto"
     )
 
     bs = 8

--- a/train.py
+++ b/train.py
@@ -216,7 +216,7 @@ def main():
         weight_decay=args.weight_decay,
         momentum=args.momentum,
         nesterov=args.use_nesterov,
-        filter_bias_and_bn=args.filter_bias_and_bn,
+        weight_decay_filter=args.weight_decay_filter,
         loss_scale=optimizer_loss_scale,
         checkpoint_path=opt_ckpt_path,
         eps=args.eps,

--- a/train.py
+++ b/train.py
@@ -210,13 +210,14 @@ def main():
     else:
         optimizer_loss_scale = 1.0
     optimizer = create_optimizer(
-        network.trainable_params(),
+        network,
         opt=args.opt,
         lr=lr_scheduler,
         weight_decay=args.weight_decay,
         momentum=args.momentum,
         nesterov=args.use_nesterov,
         weight_decay_filter=args.weight_decay_filter,
+        layer_decay=args.layer_decay,
         loss_scale=optimizer_loss_scale,
         checkpoint_path=opt_ckpt_path,
         eps=args.eps,

--- a/train_with_func.py
+++ b/train_with_func.py
@@ -227,7 +227,7 @@ def main():
         weight_decay=args.weight_decay,
         momentum=args.momentum,
         nesterov=args.use_nesterov,
-        filter_bias_and_bn=args.filter_bias_and_bn,
+        weight_decay_filter=args.weight_decay_filter,
         loss_scale=1.0,
         eps=args.eps,
     )


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

Fix the bug with weight decay when set `filter_bias_and_bn`:

1. When `filter_bias_and_bn` is `True`: function `init_group_params` does not set value of weight decay for `no_decay_params`, in this case, mindspore will use `weight_decay` of optimizer (usually not 0.0).
2. When `filter_bias_and_bn` is `False`: mindspore will automatically filter BatchNorm params from weight_decay.

So the name of the argument is not the same as what it actually does. And we can never filter out the param of bias and norm layer from doing weight decay, as the name `filter_bias_and_bn`.

Due to this, we refactor it to `weight_decay_filter`:
- `"disable"`: No parameters to filter.
- `"auto"`: We do not apply weight decay filtering to any parameters. However, MindSpore currently automatically filters the parameters of Norm layer from weight decay.
- `"norm_and_bias"`: Filter the paramters of Norm layer and Bias from weight decay.

How do I migrate from an old configuration?
| filter_bias_and_bn | weight_decay_filter |
|  ----  | ----  |
| `True` | `"disable"` |
| `False` | `"auto"` |

> Keep in mind that filter_bias_and_bn doesn't do what its name suggests.

BTW, we also support get no_weight_decay list from model and layer_decay.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
