### PR TITLE
fix: add warmup to squeezenet_1.0 config to make the training be stable.

### DIFF
--- a/configs/squeezenet/README.md
+++ b/configs/squeezenet/README.md
@@ -25,9 +25,9 @@ Our reproduced model performance on ImageNet-1K is reported as follows.
 
 <div align="center">
 
-| Model         | Context | Top-1 (%) | Top-5 (%) | Params (M) | Recipe                                                                                                  | Download                                                                                    |
-|---------------|---------|-----------|-----------|------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| squeezenet1_0 | D910x8-G | 59.01     | 81.01     | 1.25 | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/squeezenet/squeezenet_1.0_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/squeezenet/squeezenet1_0-e2d78c4a.ckpt) |
+| Model         | Context | Top-1 (%) | Top-5 (%) | Params (M) | Recipe                                                                                                  | Download                                                                       |
+|---------------|---------|-----------|-----------|------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| squeezenet1_0 | D910x8-G | 58.67     | 80.61     | 1.25 | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/squeezenet/squeezenet_1.0_ascend.yaml) | [weights](https://download-mindspore.osinfra.cn/toolkits/mindcv/squeezenet/squeezenet1_0-eb911778.ckpt) |
 | squeezenet1_0 | GPUx8-G | 58.83     | 81.08     | 1.25 | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/squeezenet/squeezenet_1.0_gpu.yaml)    | [weights](https://download.mindspore.cn/toolkits/mindcv/squeezenet/squeezenet1_0_gpu-685f5941.ckpt) |
 | squeezenet1_1 | D910x8-G | 58.44     | 80.84     | 1.24 | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/squeezenet/squeezenet_1.1_ascend.yaml) | [weights](https://download.mindspore.cn/toolkits/mindcv/squeezenet/squeezenet1_1-da256d3a.ckpt) |
 | squeezenet1_1 | GPUx8-G | 59.18     | 81.41     | 1.24 | [yaml](https://github.com/mindspore-lab/mindcv/blob/main/configs/squeezenet/squeezenet_1.1_gpu.yaml)    | [weights](https://download.mindspore.cn/toolkits/mindcv/squeezenet/squeezenet1_1_gpu-0e33234a.ckpt) |

--- a/configs/squeezenet/squeezenet_1.0_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.0_ascend.yaml
@@ -40,7 +40,7 @@ label_smoothing: 0.1
 scheduler: 'warmup_cosine_decay'
 min_lr: 0.0
 lr: 0.1
-warmup_epochs: 0
+warmup_epochs: 5
 decay_epochs: 200
 
 # optimizer


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation
squeezenet_1.0在以前的配置下不能稳定训练，偶尔会有validation accuracy 1.0的情况。为了使训练稳定，在训练配置的yaml文件中增加了warmup_epochs=5。
SqueezeNet_1.0 could not be trained stably under the previous configuration, occasionally resulting in a validation accuracy of 1.0. To stabilize the training, warmup_epochs=5 was added in the training configuration yaml file.

## Test Plan
(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs
(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
