### PR TITLE
fix: fix bugs of pvt

### DIFF
--- a/mindcv/models/layers/compatibility.py
+++ b/mindcv/models/layers/compatibility.py
@@ -7,6 +7,7 @@ __all__ = [
     "Dropout",
     "Interpolate",
     "Split",
+    "ResizeBilinear",
 ]
 
 
@@ -83,3 +84,24 @@ class Split(nn.Cell):
 
     def construct(self, x):
         return ops.split(x, **self.kwargs)
+
+
+class ResizeBilinear(nn.Cell):
+    def __init__(self, size, align_corners=False, half_pixel_centers=False):
+        super().__init__()
+        if hasattr(nn, "ResizeBilinearV2"):
+            self.resize_bilinear = ops.ResizeBilinearV2(
+                align_corners=align_corners, half_pixel_centers=half_pixel_centers
+            )
+            self.size = size
+        else:
+            self.resize_bilinear = ops.ResizeBilinear(
+                size=size, align_corners=align_corners, half_pixel_centers=half_pixel_centers
+            )
+            self.size = None
+
+    def construct(self, x):
+        if self.size:
+            return self.resize_bilinear(x, self.size)
+        else:
+            return self.resize_bilinear(x)


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

1. Use `ops.ResizeBilinearV2` to replace `ops.ResizeBilinear` because MindSpore modified the interface.
2. Use `np.linspace` instead of `ops.linspace` since some bugs in `ops.linspace` have not been fixed yet .

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
