### PR TITLE
fix deeplabv3 loss issue via SATURATION_MODE

### DIFF
--- a/configs/squeezenet/squeezenet_1.0_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.0_ascend.yaml
@@ -30,7 +30,7 @@ keep_checkpoint_max: 10
 ckpt_save_dir: './ckpt'
 epoch_size: 200
 dataset_sink_mode: True
-amp_level: 'O2'
+amp_level: 'O0'
 
 # loss
 loss: 'CE'


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
Fix deeplabv3 loss getting nan issue by setting the SATURATION MODE environment variable.
通过设置SATURATION MODE环境变量修复deeplabv3 loss变为nan的问题。


## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
