### PR TITLE
Make ssd data module compatible with mindspore v2.0+ version

### DIFF
--- a/configs/squeezenet/squeezenet_1.0_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.0_ascend.yaml
@@ -30,7 +30,7 @@ keep_checkpoint_max: 10
 ckpt_save_dir: './ckpt'
 epoch_size: 200
 dataset_sink_mode: True
-amp_level: 'O2'
+amp_level: 'O0'
 
 # loss
 loss: 'CE'


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
Make ssd data module compatible with mindspore v2.0+ version.
ssd适配mindspore 2.0以后版本的新接口。

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
