### PR TITLE
Make ssd data module compatible with mindspore v2.0+ version 

### DIFF
--- a/configs/squeezenet/squeezenet_1.0_ascend.yaml
+++ b/configs/squeezenet/squeezenet_1.0_ascend.yaml
@@ -30,7 +30,7 @@ keep_checkpoint_max: 10
 ckpt_save_dir: './ckpt'
 epoch_size: 200
 dataset_sink_mode: True
-amp_level: 'O2'
+amp_level: 'O0'
 
 # loss
 loss: 'CE'

--- a/examples/det/ssd/data.py
+++ b/examples/det/ssd/data.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 
 import cv2
@@ -175,14 +176,21 @@ def create_ssd_dataset(
             output_columns = ["img_id", "image", "image_shape"]
             trans = [normalize_op, change_swap_op]
 
+        # Note: mindspore-2.0 delete the parameter column_order
+        sig = inspect.signature(ds.map)
+        pass_column_order = False if "kwargs" in sig.parameters else True
+
         ds = ds.map(
             operations=compose_map_func,
             input_columns=["img_id", "image", "annotation"],
             output_columns=output_columns,
-            column_order=output_columns,
+            column_order=output_columns if pass_column_order else None,
             python_multiprocessing=python_multiprocessing,
             num_parallel_workers=num_parallel_workers,
         )
+        if not pass_column_order:
+            ds.project(output_columns=output_columns)
+
         ds = ds.map(
             operations=trans,
             input_columns=["image"],


### PR DESCRIPTION
Thank you for your contribution to the MindCV repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
Make ssd data module compatible with mindspore v2.0+ version.
ssd适配mindspore 2.0以后版本的新接口。

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
